### PR TITLE
Test all routes with a navigator

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,14 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation("com.android.support.test.espresso:espresso-contrib:3.0.2") {
+        exclude group: 'com.android.support', module: 'appcompat'
+        exclude group: 'com.android.support', module: 'support-v4'
+        exclude group: 'com.android.support', module: 'support-v7'
+        exclude group: 'com.android.support', module: 'design'
+        exclude module: 'support-annotations'
+        exclude module: 'recyclerview-v7'
+    }
     ktlint "com.github.shyiko:ktlint:0.28.0"
 }
 

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ *  License, v. 2.0. If a copy of the MPL was not distributed with this
+ *  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.contrib.DrawerActions.open
+import android.support.test.espresso.contrib.NavigationViewActions.navigateTo
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
+import android.support.test.espresso.matcher.ViewMatchers.withId
+
+
+class Navigator {
+    fun gotoFxALogin() {
+        onView(withId(R.id.buttonGetStarted)).perform(click())
+        onView(withId(R.id.logMeInButton)).check(matches(isDisplayed()))
+    }
+
+    fun gotoItemList() {
+        gotoFxALogin()
+        onView(withId(R.id.logMeInButton)).perform(click())
+        onView(withId(R.id.appDrawer)).check(matches(isDisplayed()))
+    }
+
+    fun gotoItemList_openMenu() {
+        gotoItemList()
+        val drawer = onView(withId(R.id.appDrawer))
+        drawer.check(matches(isDisplayed()))
+        drawer.perform(open())
+    }
+
+    fun gotoSettings() {
+        gotoItemList_openMenu()
+        onView(withId(R.id.navView)).perform(navigateTo(R.id.goto_settings))
+        onView(withId(R.id.settings_placeholder)).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -14,7 +14,6 @@ import android.support.test.espresso.contrib.NavigationViewActions.navigateTo
 import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 
-
 class Navigator {
     fun gotoFxALogin() {
         onView(withId(R.id.buttonGetStarted)).perform(click())

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -1,8 +1,11 @@
 package mozilla.lockbox
 
 import android.support.test.InstrumentationRegistry
+import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import mozilla.lockbox.view.RootActivity
 import org.junit.Assert.assertEquals
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -12,11 +15,31 @@ import org.junit.runner.RunWith
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 @RunWith(AndroidJUnit4::class)
-class ExampleInstrumentedTest {
+open class RoutePresenterTest {
+    private val navigator = Navigator()
+
+    @Rule @JvmField
+    val activityRule: ActivityTestRule<RootActivity> = ActivityTestRule(RootActivity::class.java)
+
     @Test
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getTargetContext()
         assertEquals("mozilla.lockbox", appContext.packageName)
+    }
+
+    @Test
+    fun testFxALogin() {
+        navigator.gotoFxALogin()
+    }
+
+    @Test
+    fun testItemList() {
+        navigator.gotoItemList()
+    }
+
+    @Test
+    fun testSettings() {
+        navigator.gotoSettings()
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -6,6 +6,11 @@ package mozilla.lockbox.presenter
 
 import android.view.MenuItem
 import io.reactivex.Observable
+import io.reactivex.rxkotlin.addTo
+import mozilla.components.support.base.log.logger.Logger
+import mozilla.lockbox.R
+import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.flux.Dispatcher
 
 import mozilla.lockbox.flux.Presenter
 
@@ -15,10 +20,20 @@ interface ListEntriesProtocol {
     // TODO: Item list selection
 }
 
-class ListEntriesPresenter(private val protocol: ListEntriesProtocol) : Presenter() {
+class ListEntriesPresenter(private val protocol: ListEntriesProtocol, private val dispatcher: Dispatcher = Dispatcher.shared) : Presenter() {
     override fun onViewReady() {
         // TODO: register for drawer item selections
 
         // TODO: register for item list selections
+        protocol.drawerItemSelections.subscribe { menuItem ->
+            when (menuItem.itemId) {
+                R.id.goto_settings -> {
+                    dispatcher.dispatch(RouteAction.SETTING_LIST)
+                }
+                else -> {
+                    Logger.warn("Menu ${menuItem.title} Unimplemented")
+                }
+            }
+        }.addTo(compositeDisposable)
     }
 }

--- a/app/src/main/res/layout/fragment_item_list.xml
+++ b/app/src/main/res/layout/fragment_item_list.xml
@@ -10,7 +10,7 @@
     android:id="@+id/appDrawer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="mozilla.lockbox.view.RootActivity"
+    tools:context=".view.ItemListFragment"
     android:fitsSystemWindows="true">
 
     <LinearLayout

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -6,6 +6,7 @@
     tools:context=".view.SettingFragment">
 
     <TextView
+        android:id="@+id/settings_placeholder"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:text="@string/settings_go_here"/>

--- a/app/src/main/res/menu/nav_menu.xml
+++ b/app/src/main/res/menu/nav_menu.xml
@@ -11,5 +11,9 @@
             android:id="@+id/goto_faq"
             android:icon="@drawable/ic_help_faq"
             android:title="@string/nav_menu_faq" />
+        <item
+            android:id="@+id/goto_settings"
+            android:icon="@android:drawable/ic_menu_preferences"
+            android:title="@string/nav_menu_settings" />
     </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
 
     <string name="welcome_learn_more_btn">Learn More</string>
     <string name="nav_menu_faq">FAQ</string>
+    <string name="nav_menu_settings">Settings</string>
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">This is a placeholder for an OAuth login to FxA</string>


### PR DESCRIPTION
This PR introduces a navigator, a reusable object to make writing UI testing easier.

This is in service of testing the `RoutePresenter`.