### PR TITLE
Add JaCoCo for unit test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![Waffle Board][waffle-image]][waffle-link]
 [![Build Status][bitrise-image]][bitrise-link]
+[![codecov][codecov-image]][codecov-link]
+[![Waffle Board][waffle-image]][waffle-link]
 
 # Firefox Lockbox for Android
 
@@ -29,10 +30,12 @@ version 2.0][license-link].
 
 Note that some test fixtures use source code from third-party services, and are not subject to this license.
 
-[waffle-image]: https://badge.waffle.io/mozilla-lockbox/lockbox-extension.svg?columns=In%20Progress
-[waffle-link]: https://waffle.io/mozilla-lockbox/lockbox-extension
 [bitrise-image]: https://app.bitrise.io/app/20089a88380dd14d/status.svg?token=41PRDjKSm0fQCUiS2EmCkQ&branch=master
 [bitrise-link]: https://app.bitrise.io/app/20089a88380dd14d
+[codecov-image]: https://codecov.io/gh/mozilla-lockbox/lockbox-android/branch/master/graph/badge.svg
+[codecov-link]: https://codecov.io/gh/mozilla-lockbox/lockbox-android
+[waffle-image]: https://badge.waffle.io/mozilla-lockbox/lockbox-extension.svg?columns=In%20Progress
+[waffle-link]: https://waffle.io/mozilla-lockbox/lockbox-extension
 [docs-link]: docs/
 [org-website]: https://lockbox.firefox.com/
 [contributing-link]: docs/contributing.md

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,6 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
 
-apply plugin: "com.vanniktech.android.junit.jacoco"
-
 android {
     compileSdkVersion 27
     defaultConfig {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,8 @@ apply plugin: 'kotlin-android'
 
 apply plugin: 'kotlin-android-extensions'
 
+apply plugin: "com.vanniktech.android.junit.jacoco"
+
 android {
     compileSdkVersion 27
     defaultConfig {
@@ -22,6 +24,9 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,13 @@ buildscript {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-
+        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.12.0"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -13,16 +13,19 @@ buildscript {
     repositories {
         google()
         jcenter()
-        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.12.0"
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
+}
+
+plugins {
+    id "com.vanniktech.android.junit.jacoco" version "0.12.0"
 }
 
 allprojects {


### PR DESCRIPTION
Fixes #82 

- Adds gradle scripts like `jacocoTestReportDebug` and `jacocoTestReportRelease` which I've added to the bitrise builds (primary and deploy).
- Saves output to `/reports/jacoco/{buildType}/`
- Gets pulled into Codecov using a bitrise script:

https://codecov.io/gh/mozilla-lockbox/lockbox-android/branch/82-jacoco-revisited

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/49511/45972001-c6ec4380-bff7-11e8-922b-6aebb74fb1a2.png">

I started with the maven approach but decided its cleaner/simpler to try the new DSL gradle approach. What do you think @sashei?

Also added the codecov badge to the README:

<img width="449" alt="image" src="https://user-images.githubusercontent.com/49511/45974606-0ff3c600-bfff-11e8-87f8-c15c088f5e3b.png">

