### PR TITLE
Use Sealed Classes instead of Nested Enums in DataStore

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
@@ -8,11 +8,9 @@ package mozilla.lockbox.action
 
 import mozilla.lockbox.flux.Action
 
-data class DataStoreAction(val type: Type) : Action {
-    enum class Type {
-        LOCK,
-        UNLOCK,
-        RESET,
-        SYNC
-    }
+sealed class DataStoreAction : Action {
+    object LOCK : DataStoreAction()
+    object UNLOCK : DataStoreAction()
+    object RESET : DataStoreAction()
+    object SYNC : DataStoreAction()
 }

--- a/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DataStoreAction.kt
@@ -9,8 +9,8 @@ package mozilla.lockbox.action
 import mozilla.lockbox.flux.Action
 
 sealed class DataStoreAction : Action {
-    object LOCK : DataStoreAction()
-    object UNLOCK : DataStoreAction()
-    object RESET : DataStoreAction()
-    object SYNC : DataStoreAction()
+    object Lock : DataStoreAction()
+    object Unlock : DataStoreAction()
+    object Reset : DataStoreAction()
+    object Sync : DataStoreAction()
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -73,6 +73,6 @@ class ItemListPresenter(
                 .addTo(compositeDisposable)
 
         // TODO: remove this when we have proper locking / unlocking
-        dispatcher.dispatch(DataStoreAction.UNLOCK)
+        dispatcher.dispatch(DataStoreAction.Unlock)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -73,6 +73,6 @@ class ItemListPresenter(
                 .addTo(compositeDisposable)
 
         // TODO: remove this when we have proper locking / unlocking
-        dispatcher.dispatch(DataStoreAction(DataStoreAction.Type.UNLOCK))
+        dispatcher.dispatch(DataStoreAction.UNLOCK)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -62,10 +62,10 @@ open class DataStore(
         dispatcher.register
                 .filterByType(DataStoreAction::class.java)
                 .subscribe {
-                    when (it.type) {
-                        DataStoreAction.Type.LOCK -> lock()
-                        DataStoreAction.Type.UNLOCK -> unlock()
-                        DataStoreAction.Type.SYNC -> sync()
+                    when (it) {
+                        is DataStoreAction.LOCK -> lock()
+                        is DataStoreAction.UNLOCK -> unlock()
+                        is DataStoreAction.SYNC -> sync()
                     }
                 }
                 .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -28,10 +28,10 @@ open class DataStore(
     }
 
     sealed class State {
-        object UNPREPARED : State()
-        object LOCKED : State()
-        object UNLOCKED : State()
-        data class ERRORED(val error: Throwable) : State()
+        object Unprepared : State()
+        object Locked : State()
+        object Unlocked : State()
+        data class Errored(val error: Throwable) : State()
     }
 
     internal val compositeDisposable = CompositeDisposable()
@@ -47,8 +47,8 @@ open class DataStore(
         // handle state changes
         state.subscribe { state ->
             when (state) {
-                is State.LOCKED -> clearList()
-                is State.UNLOCKED -> updateList()
+                is State.Locked -> clearList()
+                is State.Unlocked -> updateList()
                 else -> Unit
             }
         }.addTo(compositeDisposable)
@@ -58,9 +58,9 @@ open class DataStore(
                 .filterByType(DataStoreAction::class.java)
                 .subscribe {
                     when (it) {
-                        is DataStoreAction.LOCK -> lock()
-                        is DataStoreAction.UNLOCK -> unlock()
-                        is DataStoreAction.SYNC -> sync()
+                        is DataStoreAction.Lock -> lock()
+                        is DataStoreAction.Unlock -> unlock()
+                        is DataStoreAction.Sync -> sync()
                     }
                 }
                 .addTo(compositeDisposable)
@@ -82,7 +82,7 @@ open class DataStore(
         backend.isLocked().then {
             if (it) {
                 backend.unlock(support.encryptionKey).then {
-                    stateSubject.onNext(State.UNLOCKED)
+                    stateSubject.onNext(State.Unlocked)
                     SyncResult.fromValue(Unit)
                 }
             } else {
@@ -105,7 +105,7 @@ open class DataStore(
         backend.isLocked().then {
             if (!it) {
                 backend.lock().then {
-                    stateSubject.onNext(State.LOCKED)
+                    stateSubject.onNext(State.Locked)
                     SyncResult.fromValue(Unit)
                 }
             } else {
@@ -131,7 +131,7 @@ open class DataStore(
             syncSubject.onSuccess(Unit)
             SyncResult.fromValue(Unit)
         }.thenCatch {
-            stateSubject.onNext(State.ERRORED(it))
+            stateSubject.onNext(State.Errored(it))
             syncSubject.onError(it)
             SyncResult.fromValue(Unit)
         }

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -40,8 +40,7 @@ class DataStoreTest : DisposingTest() {
             Assert.assertTrue(it.isEmpty())
         }.addTo(disposer)
         subject.state.subscribe {
-            Assert.assertEquals(State.Status.LOCKED, it.status)
-            Assert.assertNull(it.error)
+            Assert.assertEquals(State.LOCKED, it)
         }.addTo(disposer)
     }
 
@@ -65,8 +64,8 @@ class DataStoreTest : DisposingTest() {
         stateObserver.apply {
             // TODO: figure out why the initialized state isn't here?
             assertValueCount(2)
-            assertValueAt(0, State(State.Status.UNLOCKED))
-            assertValueAt(1, State(State.Status.LOCKED))
+            assertValueAt(0, State.UNLOCKED)
+            assertValueAt(1, State.LOCKED)
         }
         listObserver.apply {
             val results = values()

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -85,17 +85,17 @@ class DataStoreTest : DisposingTest() {
         subject.state.subscribe(stateObserver)
         subject.list.subscribe(listObserver)
 
-        dispatcher.dispatch(DataStoreAction(DataStoreAction.Type.UNLOCK))
+        dispatcher.dispatch(DataStoreAction.UNLOCK)
         Mockito.verify(support.storage).unlock(support.encryptionKey)
         Mockito.verify(support.storage).list()
         Mockito.clearInvocations(support.storage)
 
-        dispatcher.dispatch(DataStoreAction(DataStoreAction.Type.SYNC))
+        dispatcher.dispatch(DataStoreAction.SYNC)
         Mockito.verify(support.storage).sync(support.syncConfig)
         Mockito.verify(support.storage).list()
         Mockito.clearInvocations(support.storage)
 
-        dispatcher.dispatch(DataStoreAction(DataStoreAction.Type.LOCK))
+        dispatcher.dispatch(DataStoreAction.LOCK)
         Mockito.verify(support.storage).lock()
         Mockito.clearInvocations(support.storage)
     }

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -40,7 +40,7 @@ class DataStoreTest : DisposingTest() {
             Assert.assertTrue(it.isEmpty())
         }.addTo(disposer)
         subject.state.subscribe {
-            Assert.assertEquals(State.LOCKED, it)
+            Assert.assertEquals(State.Locked, it)
         }.addTo(disposer)
     }
 
@@ -64,8 +64,8 @@ class DataStoreTest : DisposingTest() {
         stateObserver.apply {
             // TODO: figure out why the initialized state isn't here?
             assertValueCount(2)
-            assertValueAt(0, State.UNLOCKED)
-            assertValueAt(1, State.LOCKED)
+            assertValueAt(0, State.Unlocked)
+            assertValueAt(1, State.Locked)
         }
         listObserver.apply {
             val results = values()
@@ -84,17 +84,17 @@ class DataStoreTest : DisposingTest() {
         subject.state.subscribe(stateObserver)
         subject.list.subscribe(listObserver)
 
-        dispatcher.dispatch(DataStoreAction.UNLOCK)
+        dispatcher.dispatch(DataStoreAction.Unlock)
         Mockito.verify(support.storage).unlock(support.encryptionKey)
         Mockito.verify(support.storage).list()
         Mockito.clearInvocations(support.storage)
 
-        dispatcher.dispatch(DataStoreAction.SYNC)
+        dispatcher.dispatch(DataStoreAction.Sync)
         Mockito.verify(support.storage).sync(support.syncConfig)
         Mockito.verify(support.storage).list()
         Mockito.clearInvocations(support.storage)
 
-        dispatcher.dispatch(DataStoreAction.LOCK)
+        dispatcher.dispatch(DataStoreAction.Lock)
         Mockito.verify(support.storage).lock()
         Mockito.clearInvocations(support.storage)
     }


### PR DESCRIPTION
Changes the `DataStoreAction` and `DataStore.State` from using nested enums to instead be sealed classes.  This better much more closely aligns with the patterns we have in iOS.