### PR TITLE
TelemetryStore implementation

### DIFF
--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -15,6 +15,7 @@ import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.log.sink.AndroidLogSink
 import mozilla.lockbox.store.ClipboardStore
+import mozilla.lockbox.store.TelemetryStore
 
 val log: Logger = Logger("Lockbox")
 class LockboxApplication : Application() {
@@ -24,6 +25,9 @@ class LockboxApplication : Application() {
 
         // use context for system service
         ClipboardStore.shared.apply(getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
+
+        // hook this context into Telemetry
+        TelemetryStore.shared.applyContext(this)
 
         // Set up Sentry using DSN (client key) from the Project Settings page on Sentry
         val ctx = this.applicationContext

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -10,10 +10,10 @@ import mozilla.lockbox.flux.Action
 import org.mozilla.telemetry.event.TelemetryEvent
 
 open class TelemetryAction(
-    val eventMethod: TelemetryEventMethod,
-    val eventObject: TelemetryEventObject,
-    val value: String?,
-    val extras: Map<String, Any>?
+    open val eventMethod: TelemetryEventMethod,
+    open val eventObject: TelemetryEventObject,
+    open val value: String?,
+    open val extras: Map<String, Any>?
 ) : Action {
     open fun createEvent(category: String = "action"): TelemetryEvent {
         val evt = TelemetryEvent.create(

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -15,17 +15,17 @@ open class TelemetryAction(
     val value: String?,
     val extras: Map<String, Any>?
 ) : Action {
-  open fun createEvent(category: String = "action"): TelemetryEvent {
-      val evt = TelemetryEvent.create(
-              category,
-              eventMethod.name,
-              eventObject.name,
-              value
-      )
-      extras?.forEach { ex -> evt.extra(ex.key, ex.value.toString()) }
+    open fun createEvent(category: String = "action"): TelemetryEvent {
+        val evt = TelemetryEvent.create(
+                category,
+                eventMethod.name,
+                eventObject.name,
+                value
+        )
+        extras?.forEach { ex -> evt.extra(ex.key, ex.value.toString()) }
 
-      return evt
-  }
+        return evt
+    }
 }
 
 enum class TelemetryEventMethod {

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -7,13 +7,26 @@
 package mozilla.lockbox.action
 
 import mozilla.lockbox.flux.Action
+import org.mozilla.telemetry.event.TelemetryEvent
 
 open class TelemetryAction(
     val eventMethod: TelemetryEventMethod,
     val eventObject: TelemetryEventObject,
     val value: String?,
     val extras: Map<String, Any>?
-) : Action
+) : Action {
+  open fun createEvent(category: String = "action"): TelemetryEvent {
+      val evt = TelemetryEvent.create(
+              category,
+              eventMethod.name,
+              eventObject.name,
+              value
+      )
+      extras?.forEach { ex -> evt.extra(ex.key, ex.value.toString()) }
+
+      return evt
+  }
+}
 
 enum class TelemetryEventMethod {
     tap,

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.action
+
+import mozilla.lockbox.flux.Action
+
+open class TelemetryAction(
+    val eventMethod: TelemetryEventMethod,
+    val eventObject: TelemetryEventObject,
+    val value: String?,
+    val extras: Map<String, Any>?
+) : Action
+
+enum class TelemetryEventMethod {
+    tap,
+    startup,
+    foreground,
+    background,
+    settingChanged,
+    show,
+    canceled,
+    login_selected,
+    autofill_locked,
+    autofill_unlocked,
+    refresh,
+    autofill_clear
+}
+
+enum class TelemetryEventObject {
+    app,
+    entry_list,
+    entry_detail,
+    learn_more,
+    reveal_password,
+    entry_copy_username_button,
+    entry_copy_password_button,
+    settings_list,
+    settings_autolock_time,
+    settings_autolock,
+    settings_reset,
+    settings_preferred_browser,
+    settings_record_usage_data,
+    settings_account,
+    settings_item_list_sort,
+    settings_faq,
+    settings_provide_feedback,
+    settings_get_support,
+    login_welcome,
+    login_fxa,
+    login_onboarding_confirmation,
+    login_learn_more,
+    autofill_onboarding,
+    autofill
+}

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -9,12 +9,12 @@ package mozilla.lockbox.action
 import mozilla.lockbox.flux.Action
 import org.mozilla.telemetry.event.TelemetryEvent
 
-open class TelemetryAction(
-    open val eventMethod: TelemetryEventMethod,
-    open val eventObject: TelemetryEventObject,
-    open val value: String?,
-    open val extras: Map<String, Any>?
-) : Action {
+abstract class TelemetryAction : Action {
+    abstract val eventMethod: TelemetryEventMethod
+    abstract val eventObject: TelemetryEventObject
+    open val value: String? get() = null
+    open val extras: Map<String, Any>? = null
+
     open fun createEvent(category: String = "action"): TelemetryEvent {
         val evt = TelemetryEvent.create(
                 category,

--- a/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
@@ -9,12 +9,15 @@ package mozilla.lockbox.store
 import android.content.Context
 import android.preference.PreferenceManager
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.BuildConfig
 import mozilla.lockbox.R
+import mozilla.lockbox.action.TelemetryAction
+import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
 import org.mozilla.telemetry.Telemetry
-import org.mozilla.telemetry.TelemetryHolder
 import org.mozilla.telemetry.config.TelemetryConfiguration
+import org.mozilla.telemetry.event.TelemetryEvent
 import org.mozilla.telemetry.net.HttpURLConnectionTelemetryClient
 import org.mozilla.telemetry.ping.TelemetryCorePingBuilder
 import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder
@@ -22,47 +25,68 @@ import org.mozilla.telemetry.schedule.jobscheduler.JobSchedulerTelemetrySchedule
 import org.mozilla.telemetry.serialize.JSONPingSerializer
 import org.mozilla.telemetry.storage.FileTelemetryStorage
 
-open class TelemetryStore(val dispatcher: Dispatcher = Dispatcher.shared) {
-    companion object {
-        val shared = TelemetryStore()
+open class TelemetryFactory {
+    open fun createTelemetry(ctx: Context): Telemetry {
+        val config = createConfiguration(ctx)
+        val storage = createStorage(config)
+        val client = createClient()
+        val scheduler = createScheduler()
+
+        return Telemetry(config, storage, client, scheduler)
+                .addPingBuilder(TelemetryCorePingBuilder(config))
+                .addPingBuilder(TelemetryMobileEventPingBuilder(config))
     }
 
-    internal val compositeDisposable = CompositeDisposable()
-
-    init {
-        // TODO: register for Telemetry actions
-    }
-
-    var appContext: Context? = null
-        set(value) {
-            field = value
-            if (value != null) {
-                setupTelemetry()
-            }
-        }
-
-    private fun setupTelemetry() {
-        val ctx = appContext ?: return
+    open fun createConfiguration(ctx: Context): TelemetryConfiguration {
         val res = ctx.resources
-
         val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
         val enabled = prefs.getBoolean(
                 res.getString(R.string.setting_key_telemetry),
                 res.getBoolean(R.bool.setting_telemetry_default))
 
-        val config = TelemetryConfiguration(ctx)
+        return TelemetryConfiguration(ctx)
                 .setAppName(res.getString(R.string.app_label))
                 .setServerEndpoint(res.getString(R.string.telemetry_server_endpoint))
                 .setUpdateChannel(BuildConfig.BUILD_TYPE)
                 .setBuildId(BuildConfig.VERSION_CODE.toString())
                 .setCollectionEnabled(enabled)
                 .setUploadEnabled(enabled)
-        val storage = FileTelemetryStorage(config, JSONPingSerializer())
-        val client = HttpURLConnectionTelemetryClient()
-        val scheduler = JobSchedulerTelemetryScheduler()
-        val telemetry = Telemetry(config, storage, client, scheduler)
-                .addPingBuilder(TelemetryCorePingBuilder(config))
-                .addPingBuilder(TelemetryMobileEventPingBuilder(config))
-        TelemetryHolder.set(telemetry)
+    }
+    open fun createStorage(config: TelemetryConfiguration) =
+            FileTelemetryStorage(config, JSONPingSerializer())
+    open fun createClient() = HttpURLConnectionTelemetryClient()
+    open fun createScheduler() = JobSchedulerTelemetryScheduler()
+}
+
+open class TelemetryStore(
+    val dispatcher: Dispatcher = Dispatcher.shared,
+    private val telemetryFactory: TelemetryFactory = TelemetryFactory()
+) {
+    companion object {
+        val shared = TelemetryStore()
+    }
+
+    internal val compositeDisposable = CompositeDisposable()
+    internal var telemetry: Telemetry? = null
+
+    init {
+        dispatcher.register
+                .filterByType(TelemetryAction::class.java)
+                .subscribe {
+                    val t = telemetry ?: return@subscribe
+                    val evt = TelemetryEvent.create(
+                            "action",
+                            it.eventMethod.name,
+                            it.eventObject.name,
+                            it.value
+                    )
+                    it.extras?.forEach { ex -> evt.extra(ex.key, ex.value.toString()) }
+                    t.queueEvent(evt)
+                }
+                .addTo(compositeDisposable)
+    }
+
+    fun applyContext(ctx: Context) {
+        telemetry = telemetryFactory.createTelemetry(ctx)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/TelemetryStore.kt
@@ -1,0 +1,68 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.store
+
+import android.content.Context
+import android.preference.PreferenceManager
+import io.reactivex.disposables.CompositeDisposable
+import mozilla.lockbox.BuildConfig
+import mozilla.lockbox.R
+import mozilla.lockbox.flux.Dispatcher
+import org.mozilla.telemetry.Telemetry
+import org.mozilla.telemetry.TelemetryHolder
+import org.mozilla.telemetry.config.TelemetryConfiguration
+import org.mozilla.telemetry.net.HttpURLConnectionTelemetryClient
+import org.mozilla.telemetry.ping.TelemetryCorePingBuilder
+import org.mozilla.telemetry.ping.TelemetryMobileEventPingBuilder
+import org.mozilla.telemetry.schedule.jobscheduler.JobSchedulerTelemetryScheduler
+import org.mozilla.telemetry.serialize.JSONPingSerializer
+import org.mozilla.telemetry.storage.FileTelemetryStorage
+
+open class TelemetryStore(val dispatcher: Dispatcher = Dispatcher.shared) {
+    companion object {
+        val shared = TelemetryStore()
+    }
+
+    internal val compositeDisposable = CompositeDisposable()
+
+    init {
+        // TODO: register for Telemetry actions
+    }
+
+    var appContext: Context? = null
+        set(value) {
+            field = value
+            if (value != null) {
+                setupTelemetry()
+            }
+        }
+
+    private fun setupTelemetry() {
+        val ctx = appContext ?: return
+        val res = ctx.resources
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(ctx)
+        val enabled = prefs.getBoolean(
+                res.getString(R.string.setting_key_telemetry),
+                res.getBoolean(R.bool.setting_telemetry_default))
+
+        val config = TelemetryConfiguration(ctx)
+                .setAppName(res.getString(R.string.app_label))
+                .setServerEndpoint(res.getString(R.string.telemetry_server_endpoint))
+                .setUpdateChannel(BuildConfig.BUILD_TYPE)
+                .setBuildId(BuildConfig.VERSION_CODE.toString())
+                .setCollectionEnabled(enabled)
+                .setUploadEnabled(enabled)
+        val storage = FileTelemetryStorage(config, JSONPingSerializer())
+        val client = HttpURLConnectionTelemetryClient()
+        val scheduler = JobSchedulerTelemetryScheduler()
+        val telemetry = Telemetry(config, storage, client, scheduler)
+                .addPingBuilder(TelemetryCorePingBuilder(config))
+                .addPingBuilder(TelemetryMobileEventPingBuilder(config))
+        TelemetryHolder.set(telemetry)
+    }
+}

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<resources>
+    <bool name="setting_telemetry_default">false</bool>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,4 +37,8 @@
     <string name="toast_username_copied">Username copied</string>
     <string name="toast_password_copied">Password copied</string>
     <string name="search_clear_content_description">button that clears search bar text</string>
+
+    <string name="setting_key_telemetry" translatable="false">setting_telemetry</string>
+
+    <string name="telemetry_server_endpoint" translatable="false">https://incoming.telemetry.mozilla.org</string>
 </resources>

--- a/app/src/test/java/mozilla/lockbox/DisposingTest.kt
+++ b/app/src/test/java/mozilla/lockbox/DisposingTest.kt
@@ -7,6 +7,8 @@
 package mozilla.lockbox
 
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.observers.TestObserver
+import io.reactivex.rxkotlin.addTo
 import org.junit.After
 
 open class DisposingTest {
@@ -15,5 +17,11 @@ open class DisposingTest {
     @After
     open fun tearDown() {
         disposer.clear()
+    }
+
+    fun <T> createTestObserver(): TestObserver<T> {
+        val result = TestObserver.create<T>()
+        result.addTo(disposer)
+        return result
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -6,7 +6,6 @@
 
 package mozilla.lockbox.store
 
-import io.reactivex.observers.TestObserver
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.DataStoreAction
@@ -98,5 +97,4 @@ class DataStoreTest : DisposingTest() {
         Mockito.verify(support.storage).lock()
         Mockito.clearInvocations(support.storage)
     }
-
 }

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -99,9 +99,4 @@ class DataStoreTest : DisposingTest() {
         Mockito.clearInvocations(support.storage)
     }
 
-    private fun <T> createTestObserver(): TestObserver<T> {
-        val result = TestObserver.create<T>()
-        result.addTo(disposer)
-        return result
-    }
 }

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -24,7 +24,7 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(packageName = "mozilla.lockbox")
 class TelemetryStoreTest : DisposingTest() {
-    class FakeTelemetryWrapper: TelemetryWrapper() {
+    class FakeTelemetryWrapper : TelemetryWrapper() {
         val applySubject: ReplaySubject<Context> = ReplaySubject.create(1)
         val eventsSubject: ReplaySubject<TelemetryEvent> = ReplaySubject.create(1)
 
@@ -40,7 +40,6 @@ class TelemetryStoreTest : DisposingTest() {
     private lateinit var dispatcher: Dispatcher
     private lateinit var wrapper: FakeTelemetryWrapper
     private lateinit var subject: TelemetryStore
-
 
     @Before
     fun setUp() {

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -13,7 +13,6 @@ import mozilla.lockbox.action.TelemetryAction
 import mozilla.lockbox.action.TelemetryEventMethod
 import mozilla.lockbox.action.TelemetryEventObject
 import mozilla.lockbox.flux.Dispatcher
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.telemetry.event.TelemetryEvent
@@ -37,19 +36,12 @@ class TelemetryStoreTest : DisposingTest() {
         }
     }
 
-    private lateinit var dispatcher: Dispatcher
-    private lateinit var wrapper: FakeTelemetryWrapper
-    private lateinit var subject: TelemetryStore
-
-    @Before
-    fun setUp() {
-        dispatcher = Dispatcher()
-        wrapper = FakeTelemetryWrapper()
-        subject = TelemetryStore(dispatcher, wrapper)
-    }
-
     @Test
     fun testApplyConfig() {
+        val dispatcher = Dispatcher()
+        val wrapper = FakeTelemetryWrapper()
+        val subject = TelemetryStore(dispatcher, wrapper)
+
         val applyObserver = createTestObserver<Context>()
         wrapper.applySubject.subscribe(applyObserver)
         subject.applyContext(RuntimeEnvironment.application)
@@ -58,6 +50,10 @@ class TelemetryStoreTest : DisposingTest() {
 
     @Test
     fun testActionHandling() {
+        val dispatcher = Dispatcher()
+        val wrapper = FakeTelemetryWrapper()
+        val subject = TelemetryStore(dispatcher, wrapper)
+
         val eventsObserver = createTestObserver<TelemetryEvent>()
         wrapper.eventsSubject.subscribe(eventsObserver)
 

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -1,0 +1,71 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.store
+
+import android.content.Context
+import io.reactivex.subjects.ReplaySubject
+import mozilla.lockbox.DisposingTest
+import mozilla.lockbox.action.TelemetryAction
+import mozilla.lockbox.action.TelemetryEventMethod
+import mozilla.lockbox.action.TelemetryEventObject
+import mozilla.lockbox.flux.Dispatcher
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.telemetry.event.TelemetryEvent
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(packageName = "mozilla.lockbox")
+class TelemetryStoreTest : DisposingTest() {
+    class FakeTelemetryWrapper: TelemetryWrapper() {
+        val applySubject: ReplaySubject<Context> = ReplaySubject.create(1)
+        val eventsSubject: ReplaySubject<TelemetryEvent> = ReplaySubject.create(1)
+
+        override val ready: Boolean get() = true
+        override fun apply(ctx: Context) {
+            applySubject.onNext(ctx)
+        }
+        override fun recordEvent(event: TelemetryEvent) {
+            eventsSubject.onNext(event)
+        }
+    }
+
+    private lateinit var dispatcher: Dispatcher
+    private lateinit var wrapper: FakeTelemetryWrapper
+    private lateinit var subject: TelemetryStore
+
+
+    @Before
+    fun setUp() {
+        dispatcher = Dispatcher()
+        wrapper = FakeTelemetryWrapper()
+        subject = TelemetryStore(dispatcher, wrapper)
+    }
+
+    @Test
+    fun testApplyConfig() {
+        val applyObserver = createTestObserver<Context>()
+        wrapper.applySubject.subscribe(applyObserver)
+        subject.applyContext(RuntimeEnvironment.application)
+        applyObserver.assertValue(RuntimeEnvironment.application)
+    }
+
+    @Test
+    fun testActionHandling() {
+        val eventsObserver = createTestObserver<TelemetryEvent>()
+        wrapper.eventsSubject.subscribe(eventsObserver)
+
+        var action = TelemetryAction(TelemetryEventMethod.foreground, TelemetryEventObject.app, null, null)
+        dispatcher.dispatch(action)
+        eventsObserver.assertValue {
+            it.toJSON() == action.createEvent().toJSON()
+        }
+    }
+}

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -57,7 +57,12 @@ class TelemetryStoreTest : DisposingTest() {
         val eventsObserver = createTestObserver<TelemetryEvent>()
         wrapper.eventsSubject.subscribe(eventsObserver)
 
-        var action = TelemetryAction(TelemetryEventMethod.foreground, TelemetryEventObject.app, null, null)
+        var action = object : TelemetryAction() {
+            override val eventMethod: TelemetryEventMethod
+                get() = TelemetryEventMethod.foreground
+            override val eventObject: TelemetryEventObject
+                get() = TelemetryEventObject.app
+        }
         dispatcher.dispatch(action)
         eventsObserver.assertValue {
             it.toJSON() == action.createEvent().toJSON()


### PR DESCRIPTION
Fixes #116

Implements a Flux store + actions around Telemetry, using `service-telemetry` as the basis.  This work takes the requirements drafting in #110 into account.

**NOTE:**  The enumerations are defined to exactly map to their metrics values rather than adhere, in order to take as much advantage of the system's defaults as we can.  This means they deviate from coding standards.