### PR TITLE
add delay check for clear clipboard username/password if still present

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -51,16 +51,19 @@ open class ClipboardStore(
     private fun addToClipboard(label: String, str: String) {
         val clip = ClipData.newPlainText(label, str)
         clipboardManager.primaryClip = clip
-        clearClipboard(clipDataClearDelay, str)
+        timedReplaceDirty("", str)
     }
 
-    private fun clearClipboard(delay: Long, clearStr: String) {
+    private fun timedReplaceDirty(dirty: String, clean: String, delay: Long = clipDataClearDelay){
         Handler().postDelayed({
-            val clipData = clipboardManager.primaryClip.getItemAt(0)
-            if (clipData.text == clearStr) {
-
-                clipboardManager.primaryClip = ClipData.newPlainText("", "")
-            }
+            replaceDirty(dirty, clean)
         }, delay)
+    }
+
+    fun replaceDirty(dirty: String, clean: String) {
+        val clipData = clipboardManager.primaryClip.getItemAt(0)
+        if (clipData.text == clean) {
+            clipboardManager.primaryClip = ClipData.newPlainText("", dirty)
+        }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -9,7 +9,6 @@ package mozilla.lockbox.store
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.os.Handler
-import android.util.Log
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.action.ClipboardAction
@@ -24,7 +23,7 @@ open class ClipboardStore(
         val shared = ClipboardStore()
     }
 
-    private val clipDataClearDelay = 60000L
+    private val defaultClipboardTimeout = 60000L
     private lateinit var clipboardManager: ClipboardManager
 
     init {
@@ -48,22 +47,22 @@ open class ClipboardStore(
         clipboardManager = manager
     }
 
-    private fun addToClipboard(label: String, str: String) {
-        val clip = ClipData.newPlainText(label, str)
+    private fun addToClipboard(label: String, string: String) {
+        val clip = ClipData.newPlainText(label, string)
         clipboardManager.primaryClip = clip
-        timedReplaceDirty(str)
+        timedReplaceDirty(string)
     }
 
-    private fun timedReplaceDirty(dirty: String, delay: Long = clipDataClearDelay){
+    private fun timedReplaceDirty(dirty: String, clean: String = "", delay: Long = defaultClipboardTimeout) {
         Handler().postDelayed({
-            replaceDirty(dirty)
+            replaceDirty(dirty, clean)
         }, delay)
     }
 
-    fun replaceDirty(dirty: String) {
+    fun replaceDirty(dirty: String, clean: String = "") {
         val clipData = clipboardManager.primaryClip.getItemAt(0)
         if (clipData.text == dirty) {
-            clipboardManager.primaryClip = ClipData.newPlainText("", "")
+            clipboardManager.primaryClip = ClipData.newPlainText("", clean)
         }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -51,19 +51,19 @@ open class ClipboardStore(
     private fun addToClipboard(label: String, str: String) {
         val clip = ClipData.newPlainText(label, str)
         clipboardManager.primaryClip = clip
-        timedReplaceDirty("", str)
+        timedReplaceDirty(str)
     }
 
-    private fun timedReplaceDirty(dirty: String, clean: String, delay: Long = clipDataClearDelay){
+    private fun timedReplaceDirty(dirty: String, delay: Long = clipDataClearDelay){
         Handler().postDelayed({
-            replaceDirty(dirty, clean)
+            replaceDirty(dirty)
         }, delay)
     }
 
-    fun replaceDirty(dirty: String, clean: String) {
+    fun replaceDirty(dirty: String) {
         val clipData = clipboardManager.primaryClip.getItemAt(0)
-        if (clipData.text == clean) {
-            clipboardManager.primaryClip = ClipData.newPlainText("", dirty)
+        if (clipData.text == dirty) {
+            clipboardManager.primaryClip = ClipData.newPlainText("", "")
         }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -8,6 +8,8 @@ package mozilla.lockbox.store
 
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.os.Handler
+import android.util.Log
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.action.ClipboardAction
@@ -22,6 +24,7 @@ open class ClipboardStore(
         val shared = ClipboardStore()
     }
 
+    private val clipDataClearDelay = 60000L
     private lateinit var clipboardManager: ClipboardManager
 
     init {
@@ -48,5 +51,16 @@ open class ClipboardStore(
     private fun addToClipboard(label: String, str: String) {
         val clip = ClipData.newPlainText(label, str)
         clipboardManager.primaryClip = clip
+        clearClipboard(clipDataClearDelay, str)
+    }
+
+    private fun clearClipboard(delay: Long, clearStr: String) {
+        Handler().postDelayed({
+            val clipData = clipboardManager.primaryClip.getItemAt(0)
+            if (clipData.text == clearStr) {
+
+                clipboardManager.primaryClip = ClipData.newPlainText("", "")
+            }
+        }, delay)
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
@@ -62,7 +62,6 @@ class ClipboardStoreTest : DisposingTest() {
     @Test
     fun testReplaceDirty() {
         val testString = "my_test_password"
-        val dirtyString = ""
 
         subject.apply(RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
         dispatcher.dispatch(ClipboardAction.CopyPassword(testString))
@@ -70,7 +69,7 @@ class ClipboardStoreTest : DisposingTest() {
         val clipboardManager: ClipboardManager = RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         assertTrue(clipboardManager.primaryClip.getItemAt(0).text.equals(testString))
 
-        ClipboardStore.shared.replaceDirty(dirtyString, testString)
-        assertTrue(clipboardManager.primaryClip.getItemAt(0).text.equals(dirtyString))
+        ClipboardStore.shared.replaceDirty(testString)
+        assertTrue(clipboardManager.primaryClip.getItemAt(0).text.equals(""))
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
@@ -58,4 +58,19 @@ class ClipboardStoreTest : DisposingTest() {
         val clipboardManager: ClipboardManager = RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
         assertTrue(clipboardManager.primaryClip.getItemAt(0).text.equals(testString))
     }
+
+    @Test
+    fun testReplaceDirty() {
+        val testString = "my_test_password"
+        val dirtyString = ""
+
+        subject.apply(RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
+        dispatcher.dispatch(ClipboardAction.CopyPassword(testString))
+
+        val clipboardManager: ClipboardManager = RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        assertTrue(clipboardManager.primaryClip.getItemAt(0).text.equals(testString))
+
+        ClipboardStore.shared.replaceDirty(dirtyString, testString)
+        assertTrue(clipboardManager.primaryClip.getItemAt(0).text.equals(dirtyString))
+    }
 }


### PR DESCRIPTION
Fixes #49 

add timer for clear username or password added in clipboard only if still present, if any other clipboard entry was added after is not cleared