### PR TITLE
Rearrange the navigation graph to ensure the lockscreen clears the back stack

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -66,6 +66,16 @@ class Navigator {
         onView(withId(R.id.settings_placeholder)).check(matches(isDisplayed()))
     }
 
+    fun gotoLockScreen() {
+        gotoItemList_openMenu()
+        onView(withId(R.id.navView)).perform(navigateTo(R.id.action_itemList_to_locked))
+        checkAtLockScreen()
+    }
+
+    private fun checkAtLockScreen() {
+        onView(withId(R.id.unlockButton)).check(matches(isDisplayed()))
+    }
+
     fun gotoItemDetail() {
         gotoItemList()
         gotoItemDetail_from_itemList()

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -58,7 +58,7 @@ class Navigator {
 
     fun gotoSettings() {
         gotoItemList_openMenu()
-        onView(withId(R.id.navView)).perform(navigateTo(R.id.action_itemList_to_setting))
+        onView(withId(R.id.navView)).perform(navigateTo(R.id.fragment_setting))
         checkAtSettings()
     }
 
@@ -68,7 +68,7 @@ class Navigator {
 
     fun gotoLockScreen() {
         gotoItemList_openMenu()
-        onView(withId(R.id.navView)).perform(navigateTo(R.id.action_itemList_to_locked))
+        onView(withId(R.id.navView)).perform(navigateTo(R.id.fragment_locked))
         checkAtLockScreen()
     }
 

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -75,4 +75,10 @@ open class RoutePresenterTest {
         navigator.back()
         navigator.checkAtItemList()
     }
+
+    @Test
+    fun testLockScreen() {
+        navigator.gotoLockScreen()
+        navigator.back(false)
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -6,21 +6,25 @@
 
 package mozilla.lockbox.presenter
 
+import android.support.annotation.IdRes
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.addTo
+import mozilla.lockbox.R
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.extensions.mapToItemViewModelList
 import mozilla.lockbox.flux.Dispatcher
 
 import mozilla.lockbox.flux.Presenter
+import mozilla.lockbox.log
 import mozilla.lockbox.model.ItemViewModel
 import mozilla.lockbox.store.DataStore
 
 interface ItemListView {
     val itemSelection: Observable<ItemViewModel>
     val filterClicks: Observable<Unit>
+    val menuItemSelections: Observable<Int>
     fun updateItems(itemList: List<ItemViewModel>)
 }
 
@@ -49,7 +53,21 @@ class ItemListPresenter(
                 }
                 .addTo(compositeDisposable)
 
+        view.menuItemSelections
+            .subscribe(this::onMenuItem)
+            .addTo(compositeDisposable)
+
         // TODO: remove this when we have proper locking / unlocking
         dispatcher.dispatch(DataStoreAction.Unlock)
+    }
+
+    fun onMenuItem(@IdRes item: Int) {
+        val action = when (item) {
+            R.id.action_itemList_to_locked, R.id.fragment_locked -> RouteAction.LockScreen
+            R.id.action_itemList_to_setting, R.id.fragment_setting -> RouteAction.SettingList
+            else -> return log.error("Cannot route from item list menu")
+        }
+
+        dispatcher.dispatch(action)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -61,10 +61,10 @@ class ItemListPresenter(
         dispatcher.dispatch(DataStoreAction.Unlock)
     }
 
-    fun onMenuItem(@IdRes item: Int) {
+    private fun onMenuItem(@IdRes item: Int) {
         val action = when (item) {
-            R.id.action_itemList_to_locked, R.id.fragment_locked -> RouteAction.LockScreen
-            R.id.action_itemList_to_setting, R.id.fragment_setting -> RouteAction.SettingList
+            R.id.fragment_locked -> RouteAction.LockScreen
+            R.id.fragment_setting -> RouteAction.SettingList
             else -> return log.error("Cannot route from item list menu")
         }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.support.annotation.IdRes
-import android.support.v4.content.ContextCompat.startActivity
 import android.support.v7.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
@@ -31,6 +30,31 @@ class RoutePresenter(
     override fun onViewReady() {
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
         routeStore.routes.subscribe(this::route).addTo(compositeDisposable)
+    }
+
+    private fun route(destination: RouteAction) {
+        when (destination) {
+            is RouteAction.Welcome -> navigateToFragment(destination, R.id.fragment_welcome)
+            is RouteAction.Login -> navigateToFragment(destination, R.id.fragment_fxa_login)
+            is RouteAction.ItemList -> navigateToFragment(destination, R.id.fragment_item_list)
+            is RouteAction.SettingList -> navigateToFragment(destination, R.id.fragment_setting)
+            is RouteAction.LockScreen -> navigateToFragment(destination, R.id.fragment_locked)
+            is RouteAction.Filter -> navigateToFragment(destination, R.id.fragment_filter)
+            is RouteAction.ItemDetail -> {
+                // Possibly overkill for passing a single id string,
+                // but it's typesafe™.
+                val bundle = ItemDetailFragmentArgs.Builder()
+                    .setItemId(destination.id)
+                    .build()
+                    .toBundle()
+                navigateToFragment(destination, R.id.fragment_item_detail, bundle)
+            }
+            is RouteAction.OpenWebsite -> {
+                openWebsite(destination.url)
+            }
+
+            is RouteAction.Back -> navController.popBackStack()
+        }
     }
 
     private fun navigateToFragment(action: RouteAction, @IdRes destinationId: Int, args: Bundle? = null) {
@@ -54,36 +78,6 @@ class RoutePresenter(
         navController.navigate(transition, args)
     }
 
-    private fun openWebsite(url: String) {
-        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        activity.startActivity(browserIntent, null)
-    }
-
-    private fun route(destination: RouteAction) {
-        when (destination) {
-            is RouteAction.Welcome -> navigateToFragment(destination, R.id.fragment_welcome)
-            is RouteAction.Login -> navigateToFragment(destination, R.id.fragment_fxa_login)
-            is RouteAction.ItemList -> navigateToFragment(destination, R.id.fragment_item_list)
-            is RouteAction.SettingList -> navigateToFragment(destination, R.id.fragment_setting)
-            is RouteAction.LockScreen -> navigateToFragment(destination, R.id.fragment_locked)
-            is RouteAction.Filter -> navigateToFragment(destination, R.id.fragment_filter)
-            is RouteAction.ItemDetail -> {
-                // Possibly overkill for passing a single id string,
-                // but it's typesafe™.
-                val bundle = ItemDetailFragmentArgs.Builder()
-                        .setItemId(destination.id)
-                        .build()
-                        .toBundle()
-                navigateToFragment(destination, R.id.fragment_item_detail, bundle)
-            }
-            is RouteAction.OpenWebsite -> {
-                openWebsite(destination.url)
-            }
-
-            is RouteAction.Back -> navController.popBackStack()
-        }
-    }
-
     private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
         // This maps two nodes in the graph_main.xml to the edge between them.
         // If a RouteAction is called from a place the graph doesn't know about then
@@ -102,5 +96,10 @@ class RoutePresenter(
         }
 
         return null
+    }
+
+    private fun openWebsite(url: String) {
+        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        activity.startActivity(browserIntent, null)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -48,7 +48,7 @@ class RoutePresenter(
             // it is too dangerous to RuntimeException.
             log.error(
                 "Cannot route from ${src.label} to $action. " +
-                    "This is a developer bug, fixable by adding an action to nav_graph.xml"
+                    "This is a developer bug, fixable by adding an action to graph_main.xml"
             )
         }
         navController.navigate(transition, args)
@@ -85,7 +85,7 @@ class RoutePresenter(
     }
 
     private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
-        // This maps two nodes in the nav_graph.xml to the edge between them.
+        // This maps two nodes in the graph_main.xml to the edge between them.
         // If a RouteAction is called from a place the graph doesn't know about then
         // the app will log.error.
         when (Pair(from, to)) {

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -20,6 +20,7 @@ import android.view.ViewGroup
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupWithNavController
+import com.jakewharton.rxbinding2.support.design.widget.itemSelections
 import com.jakewharton.rxbinding2.support.v7.widget.navigationClicks
 import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.Observable
@@ -85,6 +86,17 @@ class ItemListFragment : CommonFragment(), ItemListView {
 
     override val itemSelection: Observable<ItemViewModel>
         get() = adapter.clicks()
+
+    override val menuItemSelections: Observable<Int>
+        get() {
+            val navView = view!!.navView
+            val drawerLayout = view!!.appDrawer
+            return navView.itemSelections()
+                .doOnNext {
+                    drawerLayout.closeDrawer(navView)
+                }
+                .map { it.itemId }
+        }
 
     override fun updateItems(itemList: List<ItemViewModel>) {
         adapter.updateItems(itemList)

--- a/app/src/main/res/layout/activity_root.xml
+++ b/app/src/main/res/layout/activity_root.xml
@@ -17,7 +17,7 @@
         android:layout_height="match_parent"
         android:id="@+id/fragment_nav_host"
         android:name="androidx.navigation.fragment.NavHostFragment"
-        app:navGraph="@navigation/nav_graph"
+        app:navGraph="@navigation/graph_main"
         app:defaultNavHost="true"
         />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/nav_menu.xml
+++ b/app/src/main/res/menu/nav_menu.xml
@@ -13,11 +13,11 @@
             android:icon="@drawable/ic_help_faq"
             android:title="@string/nav_menu_faq" />
         <item
-            android:id="@+id/action_itemList_to_setting"
+            android:id="@+id/fragment_setting"
             android:icon="@android:drawable/ic_menu_preferences"
             android:title="@string/nav_menu_settings" />
         <item
-            android:id="@+id/action_itemList_to_locked"
+            android:id="@+id/fragment_locked"
             android:icon="@android:drawable/ic_lock_lock"
             android:title="@string/lock_now" />
     </group>

--- a/app/src/main/res/navigation/graph_locked.xml
+++ b/app/src/main/res/navigation/graph_locked.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:id="@+id/graph_locked"
+            app:startDestination="@id/fragment_locked">
+    <fragment
+            android:id="@+id/fragment_locked"
+            android:name="mozilla.lockbox.view.LockedFragment"
+            tools:layout="@layout/fragment_locked"/>
+</navigation>

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -8,7 +8,7 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/nav_graph"
+    android:id="@+id/graph_main"
     app:startDestination="@id/fragment_welcome">
 
     <fragment

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -42,14 +42,21 @@
             app:destination="@id/fragment_item_detail" />
         <action
             android:id="@+id/action_itemList_to_setting"
-            app:destination="@id/fragment_setting" />
+            app:destination="@id/fragment_setting"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
+        <action
+            android:id="@+id/action_itemList_to_locked"
+            app:destination="@+id/graph_locked"
+            app:launchSingleTop="true"
+            app:clearTask="true"
+            app:popUpTo="@+id/graph_locked"
+            app:popUpToInclusive="true" />
         <action
             android:id="@+id/action_itemList_to_filter"
             app:destination="@id/fragment_filter" />
-        <action
-            android:id="@+id/action_itemList_to_locked"
-            app:destination="@id/graph_locked"
-            app:launchSingleTop="true"/>
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -44,11 +44,12 @@
             android:id="@+id/action_itemList_to_setting"
             app:destination="@id/fragment_setting" />
         <action
-            android:id="@+id/action_itemList_to_locked"
-            app:destination="@+id/fragment_locked" />
-        <action
             android:id="@+id/action_itemList_to_filter"
             app:destination="@id/fragment_filter" />
+        <action
+            android:id="@+id/action_itemList_to_locked"
+            app:destination="@id/graph_locked"
+            app:launchSingleTop="true"/>
     </fragment>
 
     <fragment
@@ -57,7 +58,7 @@
         tools:layout="@layout/fragment_item_detail">
         <argument
             android:name="itemId"
-            android:defaultValue='"MISSING_ID"'
+            android:defaultValue="MISSING_ID"
             app:argType="string" />
     </fragment>
 
@@ -68,11 +69,6 @@
         tools:layout="@layout/fragment_setting"/>
 
     <fragment
-        android:id="@+id/fragment_locked"
-        android:name="mozilla.lockbox.view.LockedFragment"
-        tools:layout="@layout/fragment_locked" />
-
-    <fragment
         android:id="@+id/fragment_filter"
         android:name="mozilla.lockbox.view.FilterFragment"
         tools:layout="@layout/fragment_filter" >
@@ -80,4 +76,6 @@
             android:id="@+id/action_filter_to_itemDetail"
             app:destination="@id/fragment_item_detail" />
     </fragment>
+
+    <include app:graph="@navigation/graph_locked" />
 </navigation>

--- a/app/src/test/java/mozilla/lockbox/extensions/Observer+.kt
+++ b/app/src/test/java/mozilla/lockbox/extensions/Observer+.kt
@@ -1,0 +1,14 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.extensions
+
+import io.reactivex.observers.TestObserver
+
+fun <T> TestObserver<T>.assertLastValue(expectedValue: T) {
+    val count = this.valueCount()
+    this.assertValueAt(count - 1, expectedValue)
+}

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
@@ -133,13 +133,7 @@ class ItemListPresenterTest {
         view.menuItemSelectionStub.onNext(R.id.fragment_setting)
         dispatcherObserver.assertLastValue(RouteAction.SettingList)
 
-        view.menuItemSelectionStub.onNext(R.id.action_itemList_to_setting)
-        dispatcherObserver.assertLastValue(RouteAction.SettingList)
-
         view.menuItemSelectionStub.onNext(R.id.fragment_locked)
-        dispatcherObserver.assertLastValue(RouteAction.LockScreen)
-
-        view.menuItemSelectionStub.onNext(R.id.action_itemList_to_locked)
         dispatcherObserver.assertLastValue(RouteAction.LockScreen)
     }
 }


### PR DESCRIPTION
Fixes #143

This PR re-implements detecting the menu item selections to use the dispatcher to call the `navController`.

This is because the blessed way of using the appDrawer with the navController constructed its own action (and animations) instead of using the one we specifiy in the `graph.xml`. This adds those default animations to the settings action, and changes the action to the locked screen to clear the back stack.

Additionally, the locked screen is moved to its own subgraph.

Unfortunately, the action to transition to the locked screen can't be made into a global action yet, due to a bug in the navigation library.