### PR TITLE
[WIP] Select a start screen based upon datastore state.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox.presenter
 
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.addTo
+import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
@@ -19,7 +20,7 @@ interface FxALoginViewProtocol {
 class FxALoginPresenter(private val view: FxALoginViewProtocol, private val dispatcher: Dispatcher = Dispatcher.shared) : Presenter() {
     override fun onViewReady() {
         this.view.logMeInClicks.subscribe {
-            dispatcher.dispatch(RouteAction.ItemList)
+            dispatcher.dispatch(DataStoreAction.Unlock)
         }.addTo(compositeDisposable)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -56,14 +56,11 @@ class ItemListPresenter(
         view.menuItemSelections
             .subscribe(this::onMenuItem)
             .addTo(compositeDisposable)
-
-        // TODO: remove this when we have proper locking / unlocking
-        dispatcher.dispatch(DataStoreAction.Unlock)
     }
 
     private fun onMenuItem(@IdRes item: Int) {
         val action = when (item) {
-            R.id.fragment_locked -> RouteAction.LockScreen
+            R.id.fragment_locked -> DataStoreAction.Lock
             R.id.fragment_setting -> RouteAction.SettingList
             else -> return log.error("Cannot route from item list menu")
         }

--- a/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox.presenter
 
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.addTo
+import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
@@ -22,7 +23,7 @@ class LockedPresenter(
 ) : Presenter() {
     override fun onViewReady() {
         view.unlockButtonTaps
-                .subscribe { dispatcher.dispatch(RouteAction.ItemList) }
+                .subscribe { dispatcher.dispatch(DataStoreAction.Unlock) }
                 .addTo(compositeDisposable)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -29,6 +29,8 @@ class RoutePresenter(
 
     override fun onViewReady() {
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
+        navController.setGraph(R.navigation.graph_main)
+
         routeStore.routes.subscribe(this::route).addTo(compositeDisposable)
     }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -13,17 +13,22 @@ import android.support.annotation.IdRes
 import android.support.v7.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
+import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.R
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Presenter
 import mozilla.lockbox.log
+import mozilla.lockbox.store.DataStore
+import mozilla.lockbox.store.DataStore.State
 import mozilla.lockbox.store.RouteStore
 import mozilla.lockbox.view.ItemDetailFragmentArgs
 
 class RoutePresenter(
     private val activity: AppCompatActivity,
-    private val routeStore: RouteStore = RouteStore.shared
+    private val routeStore: RouteStore = RouteStore.shared,
+
+    private val dataStore: DataStore = DataStore.shared
 ) : Presenter() {
     private lateinit var navController: NavController
 
@@ -31,7 +36,25 @@ class RoutePresenter(
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
         navController.setGraph(R.navigation.graph_main)
 
-        routeStore.routes.subscribe(this::route).addTo(compositeDisposable)
+        dataStore.state
+            .observeOn(mainThread())
+            .map(this::dataStoreRoutes)
+            .subscribe(this::route)
+            .addTo(compositeDisposable)
+
+        routeStore.routes
+            .observeOn(mainThread())
+            .subscribe(this::route)
+            .addTo(compositeDisposable)
+    }
+
+    private fun dataStoreRoutes(storageState: State): RouteAction {
+        return when (storageState) {
+            is State.Unlocked -> RouteAction.ItemList
+            is State.Locked -> RouteAction.LockScreen
+            is State.Unprepared -> RouteAction.Welcome
+            else -> RouteAction.LockScreen
+        }
     }
 
     private fun route(destination: RouteAction) {
@@ -84,20 +107,20 @@ class RoutePresenter(
         // This maps two nodes in the graph_main.xml to the edge between them.
         // If a RouteAction is called from a place the graph doesn't know about then
         // the app will log.error.
-        when (Pair(from, to)) {
-            Pair(R.id.fragment_welcome, R.id.fragment_fxa_login) -> return R.id.action_welcome_to_fxaLogin
+        return when (Pair(from, to)) {
+            Pair(R.id.fragment_welcome, R.id.fragment_fxa_login) -> R.id.action_welcome_to_fxaLogin
 
-            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> return R.id.action_fxaLogin_to_itemList
+            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
 
-            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> return R.id.action_itemList_to_itemDetail
-            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> return R.id.action_itemList_to_setting
-            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> return R.id.action_itemList_to_locked
-            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> return R.id.action_itemList_to_filter
+            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> R.id.action_itemList_to_itemDetail
+            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> R.id.action_itemList_to_setting
+            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_itemList_to_locked
+            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
 
-            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> return R.id.action_filter_to_itemDetail
+            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail
+
+            else -> null
         }
-
-        return null
     }
 
     private fun openWebsite(url: String) {

--- a/app/src/main/res/layout/activity_root.xml
+++ b/app/src/main/res/layout/activity_root.xml
@@ -17,7 +17,6 @@
         android:layout_height="match_parent"
         android:id="@+id/fragment_nav_host"
         android:name="androidx.navigation.fragment.NavHostFragment"
-        app:navGraph="@navigation/graph_main"
         app:defaultNavHost="true"
         />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -9,29 +9,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/graph_main"
-    app:startDestination="@id/fragment_welcome">
-
-    <fragment
-        android:id="@+id/fragment_welcome"
-        android:name="mozilla.lockbox.view.WelcomeFragment"
-        tools:layout="@layout/fragment_welcome">
-        <action
-            android:id="@+id/action_welcome_to_fxaLogin"
-            app:destination="@id/fragment_fxa_login" />
-    </fragment>
-
-    <fragment
-        android:id="@+id/fragment_fxa_login"
-        android:name="mozilla.lockbox.view.FxALoginFragment"
-        tools:layout="@layout/fragment_fxa_login">
-        <action
-            android:id="@+id/action_fxaLogin_to_itemList"
-            app:destination="@id/fragment_item_list"
-            app:launchSingleTop="true"
-            app:clearTask="true"
-            app:popUpTo="@+id/fragment_item_list"
-            app:popUpToInclusive="true" />
-    </fragment>
+    app:startDestination="@id/graph_welcome">
 
     <fragment
         android:id="@+id/fragment_item_list"
@@ -85,4 +63,27 @@
     </fragment>
 
     <include app:graph="@navigation/graph_locked" />
+
+    <navigation android:id="@+id/graph_welcome" app:startDestination="@id/fragment_welcome">
+        <fragment
+                android:id="@+id/fragment_welcome"
+                android:name="mozilla.lockbox.view.WelcomeFragment"
+                tools:layout="@layout/fragment_welcome">
+            <action
+                    android:id="@+id/action_welcome_to_fxaLogin"
+                    app:destination="@id/fragment_fxa_login"/>
+        </fragment>
+        <fragment
+                android:id="@+id/fragment_fxa_login"
+                android:name="mozilla.lockbox.view.FxALoginFragment"
+                tools:layout="@layout/fragment_fxa_login">
+            <action
+                    android:id="@+id/action_fxaLogin_to_itemList"
+                    app:destination="@id/fragment_item_list"
+                    app:launchSingleTop="true"
+                    app:clearTask="true"
+                    app:popUpTo="@+id/fragment_item_list"
+                    app:popUpToInclusive="true"/>
+        </fragment>
+    </navigation>
 </navigation>


### PR DESCRIPTION
Fixes #144
Connected to #22
Connected to #68

This PR continues to split up the graph into subgraphs, but starts sending UI actions through the DataStore.