### PR TITLE
Adding randomness for users, pwds, and hosts for datastore entries

### DIFF
--- a/app/src/main/java/mozilla/lockbox/support/DataStoreSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/DataStoreSupport.kt
@@ -50,6 +50,7 @@ class FixedDataStoreSupport(values: List<ServerPassword>? = null) : DataStoreSup
  */
 internal fun createDummyItem(idx: Int): ServerPassword {
     val random = Random()
+    val id = UUID.randomUUID().toString()
     val pwd = createRandomPassword()
     val host = createHostname()
     val user = createUserId()
@@ -58,7 +59,7 @@ internal fun createDummyItem(idx: Int): ServerPassword {
     val changed = Date(used - 86400000).time
 
     return ServerPassword(
-        id = "0000$idx",
+        id = id,
         hostname = host,
         username = user,
         password = pwd,
@@ -93,11 +94,11 @@ internal fun createHostname(): String {
     var hostnameLength = getRandomInRange(8, 20)
     val hostname =
         buildSequence {
-            val r = Random(); while (true) yield(r.nextInt(24))
+            val r = Random(); while (true) yield(r.nextInt(26))
         }
             .take(hostnameLength)
             .map {
-                (it + 67).toChar().toLowerCase()
+                (it + 97).toChar()
             }
             .joinToString("")
 

--- a/app/src/main/java/mozilla/lockbox/support/DataStoreSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/DataStoreSupport.kt
@@ -12,6 +12,8 @@ import org.mozilla.sync15.logins.ServerPassword
 import org.mozilla.sync15.logins.SyncUnlockInfo
 import java.util.Date
 import java.util.Random
+import java.util.UUID
+import kotlin.coroutines.experimental.buildSequence
 
 interface DataStoreSupport {
     val encryptionKey: String
@@ -21,16 +23,17 @@ interface DataStoreSupport {
 
 // Fixed-Data Implementation
 class FixedDataStoreSupport(values: List<ServerPassword>? = null) : DataStoreSupport {
-    private val logins = MemoryLoginsStorage(values ?: List(10) { createDummyItem(it) })
+    var size = getRandomInRange(10, 20)
+    private val logins = MemoryLoginsStorage(values ?: List(size) { createDummyItem(it) })
 
     override val encryptionKey: String
         get() = "shh-keep-it-secret"
     override val syncConfig: SyncUnlockInfo
         get() = SyncUnlockInfo(
-                kid = "fake-kid",
-                fxaAccessToken = "fake-at",
-                syncKey = "fake-key",
-                tokenserverURL = "https://oauth.example.com/token"
+            kid = "fake-kid",
+            fxaAccessToken = "fake-at",
+            syncKey = "fake-key",
+            tokenserverURL = "https://oauth.example.com/token"
         )
 
     override fun createLoginsStorage(): LoginsStorage = logins
@@ -42,25 +45,70 @@ class FixedDataStoreSupport(values: List<ServerPassword>? = null) : DataStoreSup
 
 /**
  * Creates a test ServerPassword item
+ * Some functionality inspired by FxA 'upload_fake_passwords.py'
+ * https://gist.github.com/rfk/916d9ca684f862b1c1030c685a5a4d19
  */
 internal fun createDummyItem(idx: Int): ServerPassword {
-    val rng = Random()
-    val pos = idx + 1
-    val pwd = "AAbbcc112233!"
-    val host = "https://$pos.example.com"
+    val random = Random()
+    val pwd = createRandomPassword()
+    val host = createHostname()
+    val user = createUserId()
     val created = Date().time
     val used = Date(created - 86400000).time
     val changed = Date(used - 86400000).time
 
     return ServerPassword(
-            id = "0000$idx",
-            hostname = host,
-            username = "someone #$pos",
-            password = pwd,
-            formSubmitURL = host,
-            timeCreated = created,
-            timeLastUsed = used,
-            timePasswordChanged = changed,
-            timesUsed = rng.nextInt(100) + 1
+        id = "0000$idx",
+        hostname = host,
+        username = user,
+        password = pwd,
+        formSubmitURL = host,
+        timeCreated = created,
+        timeLastUsed = used,
+        timePasswordChanged = changed,
+        timesUsed = random.nextInt(100) + 1
     )
+}
+
+internal fun createRandomPassword(): String {
+    return UUID.randomUUID().toString().substring(0..20)
+}
+
+internal fun createHostname(): String {
+    val protocolChoices = listOf(
+        "https://www.",
+        "http://www.",
+        "https://",
+        "https://accounts."
+    )
+    val domainChoices = listOf(
+        ".com",
+        ".net",
+        ".org",
+        ".co.uk"
+    )
+    var protocol = protocolChoices[Random().nextInt(protocolChoices.size)]
+    var domain = domainChoices[Random().nextInt(domainChoices.size)]
+
+    var hostnameLength = getRandomInRange(8, 20)
+    val hostname =
+        buildSequence {
+            val r = Random(); while (true) yield(r.nextInt(24))
+        }
+            .take(hostnameLength)
+            .map {
+                (it + 67).toChar().toLowerCase()
+            }
+            .joinToString("")
+
+    return protocol + hostname + domain
+}
+
+internal fun createUserId(): String {
+    var pos = getRandomInRange(1, 27)
+    return "fakeTester$pos"
+}
+
+internal fun getRandomInRange(lower: Int, upper: Int): Int {
+    return (lower..upper).shuffled(random = Random()).first()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.kotlin_version = '1.2.51'
     ext.android_components_version = '0.28.0'
     ext.lifecycle_version = '1.1.1'
-    ext.navigation_version = '1.0.0-alpha06'
+    ext.navigation_version = '1.0.0-alpha07'
     ext.rxbinding_version = '2.2.0'
 
     repositories {


### PR DESCRIPTION
## Testing and Review Notes
This does not have an associated issue on our board. The purpose of this PR is to take some of the randomness functionality from [FxA's fake passwords](https://gist.github.com/rfk/916d9ca684f862b1c1030c685a5a4d19) in order to have better randomness in our test entries.

**Before**
<img src="https://user-images.githubusercontent.com/43795363/47679869-8184de00-db82-11e8-8270-49a72a361a1f.png" height="600"> <img src="https://user-images.githubusercontent.com/43795363/47679886-8a75af80-db82-11e8-8732-e0d28949a479.png" height="600">


**After**
<img src="https://user-images.githubusercontent.com/43795363/47679731-2f43bd00-db82-11e8-8896-7c637e3b1ce6.png" height="600"> <img src="https://user-images.githubusercontent.com/43795363/47679756-3e2a6f80-db82-11e8-933e-434eb0e7d3aa.png" height="600">

## To Do
- [x] double check the original issue to confirm it is fully satisfied - confirmed with @devinreams that it meets requirements for better usernames/passwords/hostnames
- [x] add testing notes and screenshots in PR description to help guide reviewers
- ~[ ] add unit tests~
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- ~[ ] request the "UX" team perform a design review (if/when applicable)~
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
