### PR TITLE
FxA login

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/robots/FxALoginRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/FxALoginRobot.kt
@@ -13,10 +13,10 @@ import mozilla.lockbox.R
 // FxALogin
 class FxALoginRobot : BaseTestRobot {
     override fun exists() =
-        displayed { id(R.id.logMeInButton) }
+        displayed { id(R.id.webView) }
 
     fun tapPlaceholderLogin() =
-        click { id(R.id.logMeInButton) }
+        click { id(R.id.skipFxA) }
 }
 
 fun fxaLogin(f: FxALoginRobot.() -> Unit) = FxALoginRobot().apply(f)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
         android:name=".LockboxApplication">
         <activity
             android:name=".view.RootActivity"
-            android:label="@string/app_label" >
+            android:label="@string/app_label"
+            android:windowSoftInputMode="adjustResize" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/mozilla/lockbox/action/AccountAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/AccountAction.kt
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.action
+
+import mozilla.lockbox.flux.Action
+import java.net.URL
+
+sealed class AccountAction : Action {
+    data class OauthRedirect(val url: URL) : AccountAction()
+    object Clear : AccountAction()
+}

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -14,7 +14,6 @@ import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
-import mozilla.lockbox.log
 import mozilla.lockbox.store.AccountStore
 import mozilla.lockbox.support.Constant
 
@@ -49,10 +48,9 @@ class FxALoginPresenter(
 
         accountStore.loginURL
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe( {
+            .subscribe {
                 view.loadURL(it)
-            },
-                {log.info(it.localizedMessage)})
+            }
             .addTo(compositeDisposable)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -6,11 +6,14 @@
 
 package mozilla.lockbox.presenter
 
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.action.AccountAction
+import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
+import mozilla.lockbox.log
 import mozilla.lockbox.store.AccountStore
 import mozilla.lockbox.support.Constant
 
@@ -29,11 +32,15 @@ class FxALoginPresenter(
             url?.let {
                 if (url.startsWith(Constant.FxA.redirectUri)) {
                     dispatcher.dispatch(AccountAction.OauthRedirect(url))
+                    // TODO: remove following line when centralized routing is implemented via:
+                    // https://github.com/mozilla-lockbox/lockbox-android/issues/144
+                    dispatcher.dispatch(RouteAction.ItemList)
                 }
             }
         }
 
         accountStore.loginURL
+            .observeOn(AndroidSchedulers.mainThread())
             .subscribe {
                 view.loadURL(it)
             }

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -20,7 +20,7 @@ import mozilla.lockbox.support.Constant
 
 interface FxALoginView {
     var webViewObserver: Consumer<String?>?
-    var skipFxAClicks: Observable<Unit>
+    val skipFxAClicks: Observable<Unit>
     fun loadURL(url: String)
 }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -6,20 +6,19 @@
 
 package mozilla.lockbox.presenter
 
-import io.reactivex.Observable
-import io.reactivex.rxkotlin.addTo
-import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
+import java.net.URL
 
-interface FxALoginViewProtocol {
-    val logMeInClicks: Observable<Unit>
+interface FxALoginView {
+    fun loadURL(url: URL)
 }
 
-class FxALoginPresenter(private val view: FxALoginViewProtocol, private val dispatcher: Dispatcher = Dispatcher.shared) : Presenter() {
+class FxALoginPresenter(
+    private val view: FxALoginView,
+    private val dispatcher: Dispatcher = Dispatcher.shared
+) : Presenter() {
     override fun onViewReady() {
-        this.view.logMeInClicks.subscribe {
-            dispatcher.dispatch(RouteAction.ItemList)
-        }.addTo(compositeDisposable)
+
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -6,6 +6,7 @@
 
 package mozilla.lockbox.presenter
 
+import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.addTo
@@ -19,6 +20,7 @@ import mozilla.lockbox.support.Constant
 
 interface FxALoginView {
     var webViewObserver: Consumer<String?>?
+    var skipFxAClicks: Observable<Unit>
     fun loadURL(url: String)
 }
 
@@ -39,11 +41,18 @@ class FxALoginPresenter(
             }
         }
 
+        view.skipFxAClicks
+            .subscribe {
+                dispatcher.dispatch(RouteAction.ItemList)
+            }
+            .addTo(compositeDisposable)
+
         accountStore.loginURL
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe {
+            .subscribe( {
                 view.loadURL(it)
-            }
+            },
+                {log.info(it.localizedMessage)})
             .addTo(compositeDisposable)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -26,7 +26,7 @@ import mozilla.lockbox.support.asOptional
 private const val FIREFOX_ACCOUNT_KEY = "firefox-account"
 private val FXA_SCOPES = arrayOf("profile", "https://identity.mozilla.com/apps/lockbox", "https://identity.mozilla.com/apps/oldsync")
 
-class AccountStore(
+open class AccountStore(
     private val dispatcher: Dispatcher = Dispatcher.shared,
     private val securePreferences: SecurePreferences = SecurePreferences.shared
 ) {
@@ -46,7 +46,7 @@ class AccountStore(
 
     private var fxa: FirefoxAccount? = null
 
-    val loginURL: Observable<String> = PublishSubject.create()
+    open val loginURL: Observable<String> = PublishSubject.create()
     val oauthInfo: Observable<Optional<OAuthInfo>> = PublishSubject.create()
     val profile: Observable<Optional<Profile>> = PublishSubject.create()
 

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -8,16 +8,20 @@ package mozilla.lockbox.store
 
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.addTo
 import io.reactivex.subjects.PublishSubject
+import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.OAuthInfo
 import mozilla.components.service.fxa.Profile
-import mozilla.lockbox.action.DataStoreAction
-import mozilla.lockbox.support.Optional
-import mozilla.lockbox.support.asOptional
+import mozilla.lockbox.action.AccountAction
+import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.support.Constant
+import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.SecurePreferences
-import java.lang.IllegalArgumentException
+import mozilla.lockbox.support.asOptional
+import java.net.URL
 
 private const val FIREFOX_ACCOUNT_KEY = "firefox-account"
 private val FXA_SCOPES = arrayOf("profile", "https://identity.mozilla.com/apps/lockbox", "https://identity.mozilla.com/apps/oldsync")
@@ -32,49 +36,75 @@ class AccountStore(
 
     internal val compositeDisposable = CompositeDisposable()
 
+    private val storedAccountJSON: String?
+        get() =
+            try {
+                securePreferences.getString(FIREFOX_ACCOUNT_KEY)
+            } catch (error: IllegalArgumentException) {
+                null
+            }
+
+    private var fxa: FirefoxAccount? = null
+
+    val loginURL: Observable<String> = PublishSubject.create()
     val oauthInfo: Observable<Optional<OAuthInfo>> = PublishSubject.create()
     val profile: Observable<Optional<Profile>> = PublishSubject.create()
 
     init {
-        loadStoredFirefoxAccount()
-    }
-
-    private fun loadStoredFirefoxAccount() {
-        try {
-            securePreferences.getString(FIREFOX_ACCOUNT_KEY)?.let { accountJSON ->
-                FirefoxAccount.fromJSONString(accountJSON).whenComplete {
-                    persist(it)
+        this.dispatcher.register
+            .filterByType(AccountAction::class.java)
+            .subscribe {
+                when (it) {
+                    is AccountAction.OauthRedirect -> {
+                        this.oauthLogin(it.url)
+                    }
+                    else -> {
+                        // other AccountActions handled by later tickets
+                    }
                 }
-            } ?: run {
-                pushNullAndReset()
             }
-        } catch (error: IllegalArgumentException) {
-            pushNullAndReset()
+            .addTo(compositeDisposable)
+
+        storedAccountJSON?.let { accountJSON ->
+            FirefoxAccount.fromJSONString(accountJSON).whenComplete {
+                this.fxa = it
+                this.generateLoginURL()
+                this.populateAccountInformation()
+            }
+        } ?: run {
+            Config.release().whenComplete {
+                this.fxa = FirefoxAccount(it, Constant.FxA.clientID, Constant.FxA.redirectUri)
+                this.generateLoginURL()
+
+                (this.oauthInfo as PublishSubject).onNext(Optional(null))
+                (this.profile as PublishSubject).onNext(Optional(null))
+            }
         }
     }
 
-    private fun persist(account: FirefoxAccount) {
-        account.toJSONString()?.let {
+    private fun populateAccountInformation() {
+        fxa?.toJSONString()?.let {
             securePreferences.putString(FIREFOX_ACCOUNT_KEY, it)
         }
 
         val profileSubject = profile as PublishSubject
-        account.getProfile().whenComplete {
+        fxa?.getProfile()?.whenComplete {
             profileSubject.onNext(it.asOptional())
         }
 
         val oauthSubject = oauthInfo as PublishSubject
-        account.getOAuthToken(FXA_SCOPES).whenComplete {
+        fxa?.getOAuthToken(FXA_SCOPES)?.whenComplete {
             oauthSubject.onNext(it.asOptional())
         }
     }
 
-    private fun pushNullAndReset() {
-        val profileSubject = profile as PublishSubject
-        val oauthSubject = oauthInfo as PublishSubject
-        profileSubject.onNext(Optional(null))
-        oauthSubject.onNext(Optional(null))
+    private fun generateLoginURL() {
+        this.fxa?.beginOAuthFlow(Constant.FxA.scopes, true)?.whenComplete {
+            (this.loginURL as PublishSubject).onNext(it)
+        }
+    }
 
-        dispatcher.dispatch(DataStoreAction.Reset)
+    private fun oauthLogin(url: URL) {
+
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -13,11 +13,13 @@ import io.reactivex.rxkotlin.addTo
 import io.reactivex.subjects.PublishSubject
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
+import mozilla.components.service.fxa.FxaResult
 import mozilla.components.service.fxa.OAuthInfo
 import mozilla.components.service.fxa.Profile
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.log
 import mozilla.lockbox.support.Constant
 import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.SecurePreferences

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -6,6 +6,7 @@
 
 package mozilla.lockbox.store
 
+import android.net.Uri
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
@@ -21,7 +22,6 @@ import mozilla.lockbox.support.Constant
 import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.SecurePreferences
 import mozilla.lockbox.support.asOptional
-import java.net.URL
 
 private const val FIREFOX_ACCOUNT_KEY = "firefox-account"
 private val FXA_SCOPES = arrayOf("profile", "https://identity.mozilla.com/apps/lockbox", "https://identity.mozilla.com/apps/oldsync")
@@ -104,7 +104,17 @@ class AccountStore(
         }
     }
 
-    private fun oauthLogin(url: URL) {
+    private fun oauthLogin(url: String) {
+        val uri = Uri.parse(url)
+        val code = uri.getQueryParameter("code")
+        val state = uri.getQueryParameter("state")
 
+        code?.let { it ->
+            state?.let { state ->
+                fxa?.completeOAuthFlow(it, state)?.whenComplete {
+                    this.populateAccountInformation()
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -13,13 +13,11 @@ import io.reactivex.rxkotlin.addTo
 import io.reactivex.subjects.PublishSubject
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.FirefoxAccount
-import mozilla.components.service.fxa.FxaResult
 import mozilla.components.service.fxa.OAuthInfo
 import mozilla.components.service.fxa.Profile
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
-import mozilla.lockbox.log
 import mozilla.lockbox.support.Constant
 import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.SecurePreferences

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -31,7 +31,7 @@ open class AccountStore(
     private val securePreferences: SecurePreferences = SecurePreferences.shared
 ) {
     companion object {
-        val shared = AccountStore()
+        val shared by lazy { AccountStore() }
     }
 
     internal val compositeDisposable = CompositeDisposable()
@@ -57,9 +57,6 @@ open class AccountStore(
                 when (it) {
                     is AccountAction.OauthRedirect -> {
                         this.oauthLogin(it.url)
-                    }
-                    else -> {
-                        // other AccountActions handled by later tickets
                     }
                 }
             }

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -37,12 +37,7 @@ open class AccountStore(
     internal val compositeDisposable = CompositeDisposable()
 
     private val storedAccountJSON: String?
-        get() =
-            try {
-                securePreferences.getString(FIREFOX_ACCOUNT_KEY)
-            } catch (error: IllegalArgumentException) {
-                null
-            }
+        get() = securePreferences.getString(FIREFOX_ACCOUNT_KEY)
 
     private var fxa: FirefoxAccount? = null
 

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -7,15 +7,21 @@
 package mozilla.lockbox.support
 
 class Constant {
+    class App {
+        companion object {
+            const val KEYSTORE_LABEL = "lockbox-keystore"
+        }
+    }
+
     class FxA {
-         companion object {
-             val clientID = "e7ce535d93522896"
-             val redirectUri = "https://lockbox.firefox.com/fxa/android-redirect.html"
-             val scopes = arrayOf(
-                 "profile",
-                 "https://identity.mozilla.com/apps/lockbox",
-                 "https://identity.mozilla.com/apps/oldsync"
-             )
-         }
+        companion object {
+            const val clientID = "e7ce535d93522896"
+            const val redirectUri = "https://lockbox.firefox.com/fxa/android-redirect.html"
+            val scopes = arrayOf(
+                "profile",
+                "https://identity.mozilla.com/apps/lockbox",
+                "https://identity.mozilla.com/apps/oldsync"
+            )
+        }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -9,9 +9,9 @@ package mozilla.lockbox.support
 class Constant {
     class FxA {
          companion object {
-             final val clientID = "e7ce535d93522896"
-             final val redirectUri = "https://lockbox.firefox.com/fxa/android-redirect.html"
-             final val scopes = arrayOf(
+             val clientID = "e7ce535d93522896"
+             val redirectUri = "https://lockbox.firefox.com/fxa/android-redirect.html"
+             val scopes = arrayOf(
                  "profile",
                  "https://identity.mozilla.com/apps/lockbox",
                  "https://identity.mozilla.com/apps/oldsync"

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -1,0 +1,21 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.support
+
+class Constant {
+    class FxA {
+         companion object {
+             final val clientID = "e7ce535d93522896"
+             final val redirectUri = "https://lockbox.firefox.com/fxa/android-redirect.html"
+             final val scopes = arrayOf(
+                 "profile",
+                 "https://identity.mozilla.com/apps/lockbox",
+                 "https://identity.mozilla.com/apps/oldsync"
+             )
+         }
+    }
+}

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -6,22 +6,18 @@
 
 package mozilla.lockbox.support
 
-class Constant {
-    class App {
-        companion object {
-            const val KEYSTORE_LABEL = "lockbox-keystore"
-        }
+object Constant {
+    object App {
+        const val keystoreLabel = "lockbox-keystore"
     }
 
-    class FxA {
-        companion object {
-            const val clientID = "e7ce535d93522896"
-            const val redirectUri = "https://lockbox.firefox.com/fxa/android-redirect.html"
-            val scopes = arrayOf(
-                "profile",
-                "https://identity.mozilla.com/apps/lockbox",
-                "https://identity.mozilla.com/apps/oldsync"
-            )
-        }
+    object FxA {
+        const val clientID = "e7ce535d93522896"
+        const val redirectUri = "https://lockbox.firefox.com/fxa/android-redirect.html"
+        val scopes = arrayOf(
+            "profile",
+            "https://identity.mozilla.com/apps/lockbox",
+            "https://identity.mozilla.com/apps/oldsync"
+        )
     }
 }

--- a/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
@@ -11,11 +11,10 @@ import android.util.Base64
 import mozilla.components.lib.dataprotect.Keystore
 import java.nio.charset.StandardCharsets
 
-private const val KEYSTORE_LABEL = "lockbox-keystore"
 private const val BASE_64_FLAGS = Base64.URL_SAFE or Base64.NO_PADDING
 
 open class SecurePreferences(
-    private val keystore: Keystore = Keystore(KEYSTORE_LABEL)
+    private val keystore: Keystore = Keystore(Constant.App.KEYSTORE_LABEL)
 ) {
     companion object {
         val shared = SecurePreferences()

--- a/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
+++ b/app/src/main/java/mozilla/lockbox/support/SecurePreferences.kt
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets
 private const val BASE_64_FLAGS = Base64.URL_SAFE or Base64.NO_PADDING
 
 open class SecurePreferences(
-    private val keystore: Keystore = Keystore(Constant.App.KEYSTORE_LABEL)
+    private val keystore: Keystore = Keystore(Constant.App.keystoreLabel)
 ) {
     companion object {
         val shared = SecurePreferences()
@@ -26,7 +26,6 @@ open class SecurePreferences(
         prefs = sharedPreferences
     }
 
-    @Throws
     open fun getString(key: String): String? {
         verifyKey()
 
@@ -37,7 +36,7 @@ open class SecurePreferences(
                 val plain = keystore.decryptBytes(encrypted)
                 String(plain, StandardCharsets.UTF_8)
             } catch (error: IllegalArgumentException) {
-                throw error
+                null
             }
         } else {
             null

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -6,10 +6,15 @@
 
 package mozilla.lockbox.view
 
+import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import io.reactivex.functions.Consumer
+import kotlinx.android.synthetic.main.fragment_fxa_login.*
 import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.FxALoginPresenter
@@ -17,6 +22,8 @@ import mozilla.lockbox.presenter.FxALoginView
 import java.net.URL
 
 class FxALoginFragment : BackableFragment(), FxALoginView {
+    override var webViewObserver: Consumer<String?>? = null
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -31,7 +38,15 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
         view.toolbar.setNavigationIcon(android.R.drawable.ic_menu_close_clear_cancel)
     }
 
-    override fun loadURL(url: URL) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    override fun loadURL(url: String) {
+        webView.loadUrl(url)
+
+        webView.webViewClient = object : WebViewClient() {
+            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                webViewObserver?.accept(url)
+
+                super.onPageStarted(view, url, favicon)
+            }
+        }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -10,15 +10,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.jakewharton.rxbinding2.view.clicks
-import io.reactivex.Observable
-import kotlinx.android.synthetic.main.fragment_fxa_login.view.*
 import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.FxALoginPresenter
-import mozilla.lockbox.presenter.FxALoginViewProtocol
+import mozilla.lockbox.presenter.FxALoginView
+import java.net.URL
 
-class FxALoginFragment : BackableFragment(), FxALoginViewProtocol {
+class FxALoginFragment : BackableFragment(), FxALoginView {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -33,6 +31,7 @@ class FxALoginFragment : BackableFragment(), FxALoginViewProtocol {
         view.toolbar.setNavigationIcon(android.R.drawable.ic_menu_close_clear_cancel)
     }
 
-    override val logMeInClicks: Observable<Unit>
-        get() = view!!.logMeInButton.clicks()
+    override fun loadURL(url: URL) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -59,5 +59,6 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
         webView.loadUrl(url)
     }
 
-    override var skipFxAClicks: Observable<Unit> = skipFxA.clicks()
+    override val skipFxAClicks: Observable<Unit>
+        get() = skipFxA.clicks()
 }

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -15,6 +15,8 @@ import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.jakewharton.rxbinding2.view.clicks
+import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_fxa_login.*
 import kotlinx.android.synthetic.main.fragment_fxa_login.view.*
@@ -25,7 +27,6 @@ import mozilla.lockbox.presenter.FxALoginView
 
 class FxALoginFragment : BackableFragment(), FxALoginView {
     override var webViewObserver: Consumer<String?>? = null
-
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -57,4 +58,6 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
 
         webView.loadUrl(url)
     }
+
+    override var skipFxAClicks: Observable<Unit> = skipFxA.clicks()
 }

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -19,7 +19,6 @@ import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.FxALoginPresenter
 import mozilla.lockbox.presenter.FxALoginView
-import java.net.URL
 
 class FxALoginFragment : BackableFragment(), FxALoginView {
     override var webViewObserver: Consumer<String?>? = null

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -6,15 +6,18 @@
 
 package mozilla.lockbox.view
 
+import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import io.reactivex.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_fxa_login.*
+import kotlinx.android.synthetic.main.fragment_fxa_login.view.*
 import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.FxALoginPresenter
@@ -23,13 +26,19 @@ import mozilla.lockbox.presenter.FxALoginView
 class FxALoginFragment : BackableFragment(), FxALoginView {
     override var webViewObserver: Consumer<String?>? = null
 
+    @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         presenter = FxALoginPresenter(this)
-        return inflater.inflate(R.layout.fragment_fxa_login, container, false)
+        val view = inflater.inflate(R.layout.fragment_fxa_login, container, false)
+        view.webView.settings.domStorageEnabled = true
+        view.webView.settings.javaScriptEnabled = true
+        CookieManager.getInstance().setAcceptCookie(true)
+
+        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -38,8 +47,6 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
     }
 
     override fun loadURL(url: String) {
-        webView.loadUrl(url)
-
         webView.webViewClient = object : WebViewClient() {
             override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
                 webViewObserver?.accept(url)
@@ -47,5 +54,7 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
                 super.onPageStarted(view, url, favicon)
             }
         }
+
+        webView.loadUrl(url)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -44,7 +44,7 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.toolbar.setNavigationIcon(android.R.drawable.ic_menu_close_clear_cancel)
+        view.toolbar.setNavigationIcon(R.drawable.ic_close)
     }
 
     override fun loadURL(url: String) {

--- a/app/src/main/res/layout/fragment_fxa_login.xml
+++ b/app/src/main/res/layout/fragment_fxa_login.xml
@@ -15,33 +15,13 @@
 
     <include layout="@layout/include_backable" />
 
-    <TextView
-        android:id="@+id/placeholder_text"
-        android:layout_width="wrap_content"
-        android:layout_height="18dp"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/hello_blank_fragment"
-        android:typeface="sans"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <Button
-        android:id="@+id/logMeInButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:elevation="10dp"
-        android:text="@string/fxa_login_logmein_btn"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/placeholder_text" />
-
+    <WebView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+    />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_fxa_login.xml
+++ b/app/src/main/res/layout/fragment_fxa_login.xml
@@ -18,11 +18,13 @@
     <WebView
             android:id="@+id/webView"
             android:layout_width="match_parent"
-            android:layout_height="fill_parent"/>
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
 
     <Button
             android:id="@+id/skipFxA"
-            android:layout_width="0dp"
-            android:layout_height="0dp"/>
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/transparent"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_fxa_login.xml
+++ b/app/src/main/res/layout/fragment_fxa_login.xml
@@ -5,12 +5,12 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".view.FxALoginFragment">
 
     <include layout="@layout/include_backable" />
@@ -18,11 +18,11 @@
     <WebView
             android:id="@+id/webView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-    />
+            android:layout_height="fill_parent"/>
 
-</android.support.constraint.ConstraintLayout>
+    <Button
+            android:id="@+id/skipFxA"
+            android:layout_width="0dp"
+            android:layout_height="0dp"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_fxa_login.xml
+++ b/app/src/main/res/layout/fragment_fxa_login.xml
@@ -16,6 +16,7 @@
     <include layout="@layout/include_backable" />
 
     <WebView
+            android:id="@+id/webView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,9 +19,6 @@
     <string name="sort_menu_az">Alphabetically</string>
     <string name="sort_menu_recent">Recently Used</string>
 
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">This is a placeholder for an OAuth login to FxA</string>
-    <string name="fxa_login_logmein_btn">Log Me In</string>
     <string name="placeholder_unlock_button">Unlock Firefox Lockbox</string>
     <string name="lock_now">Lock Now</string>
     <string name="all_entries_a_z">All entries (A-Z)</string>

--- a/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
@@ -4,10 +4,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package mozilla.lockbox.action
+package mozilla.lockbox.presenter
 
-import mozilla.lockbox.flux.Action
+import org.junit.Assert.*
 
-sealed class AccountAction : Action {
-    data class OauthRedirect(val url: String) : AccountAction()
+class FxALoginPresenterTest {
+
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.powermock.api.mockito.PowerMockito
 import org.powermock.core.classloader.annotations.PrepareForTest
-import org.powermock.modules.junit4.PowerMockRunner
 import org.robolectric.RobolectricTestRunner
 import org.mockito.Mockito.`when` as whenCalled
 

--- a/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
@@ -6,8 +6,69 @@
 
 package mozilla.lockbox.presenter
 
-import org.junit.Assert.*
+import io.reactivex.observers.TestObserver
+import io.reactivex.subjects.PublishSubject
+import mozilla.lockbox.action.AccountAction
+import mozilla.lockbox.flux.Action
+import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.store.AccountStore
+import mozilla.lockbox.support.Constant
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.powermock.core.classloader.annotations.PowerMockIgnore
+import org.robolectric.RobolectricTestRunner
+import org.mockito.Mockito.`when` as whenCalled
 
+@RunWith(RobolectricTestRunner::class)
 class FxALoginPresenterTest {
+    @Mock
+    val view = Mockito.mock(FxALoginView::class.java)
 
+    @Mock
+    val accountStore = Mockito.mock(AccountStore::class.java)
+
+    val dispatcherObserver = TestObserver.create<Action>()
+    val urlObservable = PublishSubject.create<String>()
+
+    lateinit var subject: FxALoginPresenter
+
+    @Before
+    fun setUp() {
+        Dispatcher.shared.register.subscribe(dispatcherObserver)
+
+        whenCalled(accountStore.loginURL).thenReturn(urlObservable)
+
+        subject = FxALoginPresenter(view, accountStore = accountStore)
+    }
+
+    @Test
+    fun onViewReady_loginURL() {
+        subject.onViewReady()
+        val url = "www.mozilla.org"
+        urlObservable.onNext(url)
+
+        verify(view).loadURL(url)
+    }
+
+    @Test
+    fun onViewReady_gettingURL_matchingRedirect() {
+        subject.onViewReady()
+        val url = Constant.FxA.redirectUri + "/moz_fake"
+        view.webViewObserver?.accept(url)
+
+        dispatcherObserver.assertValue(AccountAction.OauthRedirect(url))
+    }
+
+    @Test
+    fun onViewReady_gettingURL_notMatchingRedirect() {
+        subject.onViewReady()
+        val url = "www.mozilla.org"
+        view.webViewObserver?.accept(url)
+
+        dispatcherObserver.assertEmpty()
+    }
 }

--- a/app/src/test/java/mozilla/lockbox/support/SecurePreferencesTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/SecurePreferencesTest.kt
@@ -81,8 +81,8 @@ class SecurePreferencesTest {
         verify(keystore).generateKey()
     }
 
-    @Test(expected = IllegalArgumentException::class)
-    fun `getString, when the keystore is not available, decrypting throws an error, & the preferences contain the string, generates the key and returns the unencrypted value`() {
+    @Test
+    fun `getString, when the keystore is not available, decrypting throws an error, & the preferences contain the string, returns null`() {
         val key = "some_key"
         whenCalled(keystore.available()).thenReturn(false)
         whenCalled(preferences.contains(key)).thenReturn(true)
@@ -91,7 +91,7 @@ class SecurePreferencesTest {
         whenCalled(keystore.decryptBytes(decodeValue)).thenThrow(IllegalArgumentException())
         whenCalled(preferences.getString(key, "")).thenReturn(encodedValue)
 
-        subject.getString(key)
+        Assert.assertNull(subject.getString(key))
         verify(keystore).generateKey()
     }
 
@@ -116,20 +116,6 @@ class SecurePreferencesTest {
         whenCalled(preferences.getString(key, "")).thenReturn(encodedValue)
 
         Assert.assertEquals(String(decryptedBytes, StandardCharsets.UTF_8), subject.getString(key))
-        verify(keystore).decryptBytes(decodeValue)
-    }
-
-    @Test(expected = IllegalArgumentException::class)
-    fun `getString, when the keystore is available, decrypting throws an error, & the preferences contain the string, returns the unencrypted value`() {
-        whenCalled(keystore.available()).thenReturn(true)
-        val key = "some_key"
-        whenCalled(preferences.contains(key)).thenReturn(true)
-
-        val encodedValue = "khulhjkkjkjhhjkdsfsdf"
-        whenCalled(keystore.decryptBytes(decodeValue)).thenThrow(IllegalArgumentException())
-        whenCalled(preferences.getString(key, "")).thenReturn(encodedValue)
-
-        subject.getString(key)
         verify(keystore).decryptBytes(decodeValue)
     }
 


### PR DESCRIPTION
Fixes #22

## Testing and Review Notes

_ux reviewers:_
This is still not hooked up with Sync, so while users will be able to complete the login flow, there will be no entries from the desktop available or any user information available from the navigation drawer.

Additionally, because of the WIP routing work being done in #169, after logging in once you will need to uninstall the app to be able to login again and bypass the FxA screen :p

Lookout for not having your device connected to the internet; we don't have any useful error dialogs about that yet and the FxA signin screen will just be blank if you're not online (this bit me while testing)

_code reviewers:_
I'm not including `AccountStore` tests in this PR because the API for the FxA library is still in flux and there's a lot of overhead to writing unit tests for the cross-compiled rust code. The `a-c` update and corresponding `AccountStore` tests are addressed in issue #189.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
