### PR TITLE
[WIP] Select a start screen based upon datastore state.

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -13,6 +13,9 @@ import android.support.test.espresso.NoActivityResumedException
 import android.support.test.espresso.intent.Intents
 import br.com.concretesolutions.kappuccino.custom.intent.IntentMatcherInteractions.sentIntent
 import br.com.concretesolutions.kappuccino.custom.intent.IntentMatcherInteractions.stubIntent
+import mozilla.lockbox.action.LifecycleAction
+import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.accountSettingScreen
 import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.robots.filteredItemList
@@ -26,7 +29,12 @@ import mozilla.lockbox.robots.welcome
 import org.junit.Assert
 
 class Navigator {
+    fun gotoWelcome() {
+        Dispatcher.shared.dispatch(RouteAction.Welcome)
+    }
+
     fun gotoFxALogin() {
+        gotoWelcome()
         welcome { tapGetStarted() }
         checkAtFxALogin()
     }
@@ -35,13 +43,17 @@ class Navigator {
         fxaLogin { exists() }
     }
 
-    private fun checkAtWelcome() {
+    fun checkAtWelcome() {
         welcome { exists() }
     }
 
-    fun gotoItemList() {
-        gotoFxALogin()
-        fxaLogin { tapPlaceholderLogin() }
+    fun gotoItemList(goManuallly: Boolean = false) {
+        if (goManuallly) {
+            gotoFxALogin()
+            fxaLogin { tapPlaceholderLogin() }
+        } else {
+            Dispatcher.shared.dispatch(LifecycleAction.UseTestData)
+        }
         checkAtItemList()
     }
 
@@ -123,12 +135,6 @@ class Navigator {
         disconnectDisclaimer { exists() }
     }
 
-    fun disconnectAccountFromDisclaimer() {
-        gotoDisconnectDisclaimer()
-        disconnectDisclaimer { tapDisconnect() }
-        checkAtWelcome()
-    }
-
     @Suppress("unused")
     fun goToLockScreen() {
         // not called until we can stub FingerprintStore in tests
@@ -163,9 +169,9 @@ class Navigator {
         closeSoftKeyboard()
         try {
             pressBack()
-            Assert.assertTrue("Expected to be still in the app, but aren't", remainInApplication)
+            Assert.assertTrue("Expected to have left, but haven't", remainInApplication)
         } catch (e: NoActivityResumedException) {
-            Assert.assertFalse("Expected to have left the app, but haven't", remainInApplication)
+            Assert.assertFalse("Expected to still be in the app, but aren't", remainInApplication)
         }
     }
 }

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -47,8 +47,8 @@ class Navigator {
         welcome { exists() }
     }
 
-    fun gotoItemList(goManuallly: Boolean = false) {
-        if (goManuallly) {
+    fun gotoItemList(goManually: Boolean = false) {
+        if (goManually) {
             gotoFxALogin()
             fxaLogin { tapPlaceholderLogin() }
         } else {

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -36,9 +36,9 @@ open class RoutePresenterTest {
     @Before
     fun setUp() {
         Dispatcher.shared.dispatch(DataStoreAction.Unlock)
-        Thread.sleep(100L)
+        Thread.sleep(200L)
         Dispatcher.shared.dispatch(LifecycleAction.UserReset)
-        Thread.sleep(100L)
+        Thread.sleep(200L)
     }
 
     @Test

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -13,12 +13,10 @@ import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.robots.filteredItemList
-import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.view.RootActivity
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.jupiter.api.BeforeEach
 import org.junit.runner.RunWith
 
 /**

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.robots.filteredItemList
 import mozilla.lockbox.view.RootActivity
 import org.junit.Rule
@@ -35,7 +36,7 @@ open class RoutePresenterTest {
 
     @Test
     fun testItemList() {
-        navigator.gotoItemList()
+        navigator.gotoItemList(true)
         navigator.back(false)
     }
 
@@ -80,7 +81,9 @@ open class RoutePresenterTest {
     @Test
     fun testDisconnecting() {
         // note: this won't work until routing PR is merged
-//        navigator.disconnectAccountFromDisclaimer()
+        navigator.gotoDisconnectDisclaimer()
+        disconnectDisclaimer { tapDisconnect() }
+        navigator.checkAtWelcome()
     }
 
     @Test

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -8,11 +8,17 @@ package mozilla.lockbox
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import mozilla.lockbox.action.DataStoreAction
+import mozilla.lockbox.action.LifecycleAction
+import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.robots.filteredItemList
+import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.view.RootActivity
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
 import org.junit.runner.RunWith
 
 /**
@@ -26,6 +32,14 @@ open class RoutePresenterTest {
 
     @Rule @JvmField
     val activityRule: ActivityTestRule<RootActivity> = ActivityTestRule(RootActivity::class.java)
+
+    @Before
+    fun setUp() {
+        Dispatcher.shared.dispatch(DataStoreAction.Unlock)
+        Thread.sleep(100L)
+        Dispatcher.shared.dispatch(LifecycleAction.UserReset)
+        Thread.sleep(100L)
+    }
 
     @Test
     fun testFxALogin() {

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -22,8 +22,10 @@ import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.store.FingerprintStore
 import mozilla.lockbox.store.SettingStore
 import mozilla.lockbox.store.TelemetryStore
+import mozilla.lockbox.support.FixedDataStoreSupport
 import mozilla.lockbox.support.FxASyncDataStoreSupport
 import mozilla.lockbox.support.SecurePreferences
+import mozilla.lockbox.support.isTesting
 
 sealed class LogProvider {
     companion object {
@@ -51,7 +53,11 @@ class LockboxApplication : Application() {
         // this needs to be done after injectContext, as
         // SyncDataStoreSupport needs to find the database
         // path from the context
-        val support = FxASyncDataStoreSupport.shared
+        val support = if (isTesting()) {
+            FixedDataStoreSupport.shared
+        } else {
+            FxASyncDataStoreSupport.shared
+        }
         DataStore.shared.resetSupport(support)
     }
 

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -42,7 +42,6 @@ class LockboxApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         if (leakCanary()) return
-        if (isUnitTest()) return
         injectContext()
         setupDataStoreSupport()
         setupLifecycleListener()

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -42,6 +42,7 @@ class LockboxApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         if (leakCanary()) return
+        if (isUnitTest()) return
         injectContext()
         setupDataStoreSupport()
         setupLifecycleListener()

--- a/app/src/main/java/mozilla/lockbox/action/AccountAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/AccountAction.kt
@@ -10,5 +10,6 @@ import mozilla.lockbox.flux.Action
 
 sealed class AccountAction : Action {
     object Reset : AccountAction()
+    object UseTestData : AccountAction()
     data class OauthRedirect(val url: String) : AccountAction()
 }

--- a/app/src/main/java/mozilla/lockbox/model/SyncCredentials.kt
+++ b/app/src/main/java/mozilla/lockbox/model/SyncCredentials.kt
@@ -11,23 +11,47 @@ import mozilla.lockbox.support.FxAOauthInfo
 
 private val emptyString = ""
 
-class SyncCredentials(
+interface SyncCredentials {
+    val isNew: Boolean
+
+    val tokenServerURL: String
+    // The following three properties should only be used when we have checked that the
+    // credentials are syntactically valid, by calling `isValid`.
+    val accessToken: String
+    val kid: String
+    val syncKey: String
+    val isValid: Boolean
+}
+
+class FixedSyncCredentials(
+    override val isNew: Boolean
+) : SyncCredentials {
+    override val accessToken: String = emptyString
+    override val kid: String = emptyString
+    override val syncKey: String = emptyString
+    override val tokenServerURL: String = emptyString
+
+    override val isValid: Boolean = true
+}
+
+class FxASyncCredentials(
     private val oauthInfo: FxAOauthInfo,
-    val tokenServerURL: String,
-    private val scope: String
-) {
+    override val tokenServerURL: String,
+    private val scope: String,
+    override val isNew: Boolean
+) : SyncCredentials {
     private val scopedKey: OAuthScopedKey? by lazy {
         oauthInfo.keys?.get(scope)
     }
 
     // The following three properties should only be used when we have checked that the
     // credentials are syntactically valid, by calling `isValid`.
-    val accessToken: String = oauthInfo.accessToken
-    val kid: String
+    override val accessToken: String = oauthInfo.accessToken
+    override val kid: String
         get() = scopedKey?.kid ?: emptyString
-    val syncKey: String
+    override val syncKey: String
         get() = scopedKey?.k ?: emptyString
 
-    val isValid: Boolean
+    override val isValid: Boolean
         get() = scopedKey != null
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -11,11 +11,13 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.action.AccountAction
+import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
 import mozilla.lockbox.store.AccountStore
+import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.support.Constant
 
 interface FxALoginView {
@@ -36,7 +38,7 @@ class FxALoginPresenter(
                     dispatcher.dispatch(AccountAction.OauthRedirect(url))
                     // TODO: remove following line when centralized routing is implemented via:
                     // https://github.com/mozilla-lockbox/lockbox-android/issues/144
-                    dispatcher.dispatch(RouteAction.ItemList)
+                    dispatcher.dispatch(DataStoreAction.Unlock)
                 }
             }
         }

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -13,11 +13,9 @@ import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
-import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
 import mozilla.lockbox.store.AccountStore
-import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.support.Constant
 
 interface FxALoginView {

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -108,7 +108,11 @@ class ItemListPresenter(
             }
             .filterNotNull()
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe(view::setDisplayName)
+            .subscribe(view::setDisplayName, {
+                log.error("Lifecycle problem caused ${it.javaClass.simpleName} here", it)
+            }, {
+                log.info("onCompleted: ${javaClass.simpleName}")
+            })
             .addTo(compositeDisposable)
     }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -13,7 +13,6 @@ import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
-import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.action.SettingAction

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -110,9 +110,6 @@ class ItemListPresenter(
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(view::setDisplayName)
             .addTo(compositeDisposable)
-
-        // TODO: remove this when we have proper locking / unlocking
-        dispatcher.dispatch(DataStoreAction.Unlock)
     }
 
     private fun onMenuItem(@IdRes item: Int) {

--- a/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
@@ -10,6 +10,7 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.R
+import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.FingerprintAuthAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
@@ -63,7 +64,7 @@ class LockedPresenter(
     }
 
     private fun unlock() {
-        dispatcher.dispatch(RouteAction.ItemList)
+        dispatcher.dispatch(DataStoreAction.Unlock)
     }
 
     private fun unlockFallback() {

--- a/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
@@ -44,12 +44,9 @@ class LockedPresenter(
             .addTo(compositeDisposable)
 
         view.unlockConfirmed
+            .filter { it }
             .subscribe {
-                if (it) {
-                    dispatcher.dispatch(RouteAction.ItemList)
-                } else {
-                    dispatcher.dispatch(RouteAction.LockScreen)
-                }
+                unlock()
             }
             .addTo(compositeDisposable)
 
@@ -57,12 +54,16 @@ class LockedPresenter(
             .subscribe {
                 if (it is FingerprintAuthAction.OnAuthentication) {
                     when (it.authCallback) {
-                        is AuthCallback.OnAuth -> dispatcher.dispatch(RouteAction.ItemList)
+                        is AuthCallback.OnAuth -> unlock()
                         is AuthCallback.OnError -> unlockFallback()
                     }
                 }
             }
             .addTo(compositeDisposable)
+    }
+
+    private fun unlock() {
+        dispatcher.dispatch(RouteAction.ItemList)
     }
 
     private fun unlockFallback() {

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -230,7 +230,7 @@ class RoutePresenter(
                     "This is a developer bug, fixable by adding an action to graph_main.xml"
             )
         } else {
-            val clearBackStack = src.getAction(transition)?.navOptions?.shouldClearTask() ?: false
+            val clearBackStack = src.getAction(transition)?.navOptions?.shouldLaunchSingleTop() ?: false
             if (clearBackStack) {
                 while (navController.popBackStack()) {
                     // NOP
@@ -238,7 +238,12 @@ class RoutePresenter(
             }
         }
 
-        navController.navigate(transition, args)
+        try {
+            navController.navigate(transition, args)
+        } catch (e: IllegalArgumentException) {
+            log.error("This appears to be a bug in navController", e)
+            navController.navigate(destinationId, args)
+        }
     }
 
     private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -22,9 +22,9 @@ import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.action.SettingAction
+import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.extensions.view.AlertDialogHelper
 import mozilla.lockbox.extensions.view.AlertState
-import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
@@ -229,7 +229,15 @@ class RoutePresenter(
             log.error("Cannot route from $from to $to. " +
                     "This is a developer bug, fixable by adding an action to graph_main.xml"
             )
+        } else {
+            val clearBackStack = src.getAction(transition)?.navOptions?.shouldClearTask() ?: false
+            if (clearBackStack) {
+                while (navController.popBackStack()) {
+                    // NOP
+                }
+            }
         }
+
         navController.navigate(transition, args)
     }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -19,7 +19,6 @@ import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.R
 import mozilla.lockbox.action.DataStoreAction
-import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.action.SettingAction

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -224,9 +224,9 @@ class RoutePresenter(
         if (transition == destinationId) {
             // Without being able to detect if we're in developer mode,
             // it is too dangerous to RuntimeException.
-            log.error(
-
-                "Cannot route from ${src.label} to $action. " +
+            val from = activity.resources.getResourceName(srcId)
+            val to = activity.resources.getResourceName(destinationId)
+            log.error("Cannot route from $from to $to. " +
                     "This is a developer bug, fixable by adding an action to graph_main.xml"
             )
         }
@@ -237,22 +237,27 @@ class RoutePresenter(
         // This maps two nodes in the graph_main.xml to the edge between them.
         // If a RouteAction is called from a place the graph doesn't know about then
         // the app will log.error.
-        when (Pair(from, to)) {
-            Pair(R.id.fragment_welcome, R.id.fragment_fxa_login) -> return R.id.action_welcome_to_fxaLogin
+        return when (Pair(from, to)) {
+            Pair(R.id.fragment_welcome, R.id.fragment_fxa_login) -> R.id.action_welcome_to_fxaLogin
 
-            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> return R.id.action_fxaLogin_to_itemList
-            Pair(R.id.fragment_locked, R.id.fragment_item_list) -> return R.id.action_locked_to_itemList
+            Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
+            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
 
-            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> return R.id.action_itemList_to_itemDetail
-            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> return R.id.action_itemList_to_setting
-            Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> return R.id.action_itemList_to_accountSetting
-            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> return R.id.action_itemList_to_locked
-            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> return R.id.action_itemList_to_filter
+            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
+            Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_locked_to_itemList
 
-            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> return R.id.action_filter_to_itemDetail
+            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> R.id.action_itemList_to_itemDetail
+            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> R.id.action_itemList_to_setting
+            Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> R.id.action_itemList_to_accountSetting
+            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_itemList_to_locked
+            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
+
+            Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
+
+            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail
+
+            else -> null
         }
-
-        return null
     }
 
     private fun openWebsite(url: String) {

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -91,14 +91,15 @@ class RoutePresenter(
     private fun accountToDataStoreActions(it: Pair<SyncCredentials, State>): Optional<Action> {
         val (credentials, state) = it
 
+        if (state != State.Unprepared) {
+            return Optional(null)
+        }
+
         if (credentials is FixedSyncCredentials) {
             dataStore.resetSupport(FixedDataStoreSupport.shared)
         }
 
-        return when (state) {
-            is State.Unprepared -> DataStoreAction.UpdateCredentials(credentials)
-            else -> null
-        }.asOptional()
+        return DataStoreAction.UpdateCredentials(credentials).asOptional()
     }
 
     private fun route(action: RouteAction) {

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -7,6 +7,7 @@
 package mozilla.lockbox.store
 
 import android.net.Uri
+import android.os.Looper
 import android.webkit.CookieManager
 import android.webkit.WebStorage
 import io.reactivex.Observable
@@ -168,8 +169,10 @@ open class AccountStore(
     }
 
     private fun clear() {
-        CookieManager.getInstance().removeAllCookies { }
-        WebStorage.getInstance().deleteAllData()
+        if (Looper.myLooper() != null) {
+            CookieManager.getInstance().removeAllCookies { }
+            WebStorage.getInstance().deleteAllData()
+        }
 
         this.securePreferences.remove(Constant.Key.firefoxAccount)
         this.generateNewFirefoxAccount()

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -94,7 +94,7 @@ open class AccountStore(
     private fun populateTestAccountInformation(isNew: Boolean) {
         val profileSubject = profile as Subject
         val syncCredentialSubject = syncCredentials as Subject
-        
+
         securePreferences.putString(Constant.Key.firefoxAccount, Constant.App.testMarker)
 
         profileSubject.onNext(FixedFxAProfile().asOptional())

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -36,6 +36,7 @@ open class DataStore(
     sealed class State {
         object Unprepared : State()
         object Locked : State()
+        object Unlocking : State()
         object Unlocked : State()
         data class Errored(val error: Throwable) : State()
     }
@@ -105,6 +106,7 @@ open class DataStore(
     }
 
     private fun unlock() {
+        stateSubject.accept(State.Unlocking)
         if (backend.isLocked()) {
             backend.unlock(support.encryptionKey)
                 .asSingle(Dispatchers.Default)

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -17,7 +17,6 @@ import mozilla.appservices.logins.ServerPassword
 import mozilla.appservices.logins.SyncUnlockInfo
 import mozilla.components.service.sync.logins.AsyncLoginsStorage
 import mozilla.lockbox.action.DataStoreAction
-import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.model.SyncCredentials

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -62,7 +62,7 @@ open class DataStore(
         state.subscribe { state ->
             when (state) {
                 is State.Locked -> clearList()
-                is State.Unlocked -> updateList()
+                is State.Unlocked -> sync()
                 else -> Unit
             }
         }.addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -12,6 +12,7 @@ object Constant {
     object App {
         const val keystoreLabel = "lockbox-keystore"
         const val dbFilename = "firefox-lockbox.db"
+        const val testMarker = "TEST"
     }
 
     object FxA {

--- a/app/src/main/java/mozilla/lockbox/support/DebugSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/DebugSupport.kt
@@ -23,3 +23,12 @@ fun assertNotOnUiThread(detailMessage: String = "Should not be on the UI thread"
         throw AssertionError(detailMessage)
     }
 }
+
+fun isTesting(): Boolean {
+    try {
+        Class.forName("org.robolectric.RuntimeEnvironment")
+    } catch (e: ClassNotFoundException) {
+        return false
+    }
+    return true
+}

--- a/app/src/main/java/mozilla/lockbox/support/FxAInterface.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FxAInterface.kt
@@ -37,3 +37,10 @@ fun OAuthInfo.toFxAOauthInfo() = object : FxAOauthInfo {
     override val keys: Map<String, OAuthScopedKey>? = oauthInfo.keys
     override val scopes: List<String> = oauthInfo.scopes
 }
+
+class FixedFxAProfile : FxAProfile {
+    override val uid = "test"
+    override val email = "whovian@tardis.net"
+    override val displayName = "Jodie Whittaker"
+    override val avatar = "https://nerdist.com/wp-content/uploads/2017/11/The-Doctor-Jodie-Whittaker.jpg"
+}

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -114,4 +114,28 @@
             app:popUpTo="@+id/fragment_item_list"
             app:popUpToInclusive="true" />
     </fragment>
+
+    <action
+            android:id="@+id/action_to_locked"
+            app:clearTask="true"
+            app:destination="@+id/fragment_locked"
+            app:launchSingleTop="true"
+            app:popUpTo="@+id/fragment_locked"
+            app:popUpToInclusive="true" />
+
+    <action
+            android:id="@+id/action_to_itemList"
+            app:clearTask="true"
+            app:destination="@id/fragment_item_list"
+            app:launchSingleTop="true"
+            app:popUpTo="@+id/fragment_item_list"
+            app:popUpToInclusive="true" />
+
+    <action
+            android:id="@+id/action_to_welcome"
+            app:clearTask="true"
+            app:destination="@id/fragment_welcome"
+            app:launchSingleTop="true"
+            app:popUpTo="@+id/fragment_welcome"
+            app:popUpToInclusive="true" />
 </navigation>

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -26,7 +26,6 @@
         tools:layout="@layout/fragment_fxa_login">
         <action
             android:id="@+id/action_fxaLogin_to_itemList"
-            app:clearTask="true"
             app:destination="@id/fragment_item_list"
             app:launchSingleTop="true"
             app:popUpTo="@+id/fragment_item_list"
@@ -57,7 +56,6 @@
             app:popEnterAnim="@anim/none" />
         <action
             android:id="@+id/action_itemList_to_locked"
-            app:clearTask="true"
             app:destination="@+id/fragment_locked"
             app:enterAnim="@anim/slide_in_bottom"
             app:exitAnim="@anim/none"
@@ -108,7 +106,6 @@
         tools:layout="@layout/fragment_locked">
         <action
             android:id="@+id/action_locked_to_itemList"
-            app:clearTask="true"
             app:destination="@id/fragment_item_list"
             app:launchSingleTop="true"
             app:popUpTo="@+id/fragment_item_list"
@@ -117,7 +114,6 @@
 
     <action
             android:id="@+id/action_to_locked"
-            app:clearTask="true"
             app:destination="@+id/fragment_locked"
             app:launchSingleTop="true"
             app:popUpTo="@+id/fragment_locked"
@@ -125,7 +121,6 @@
 
     <action
             android:id="@+id/action_to_itemList"
-            app:clearTask="true"
             app:destination="@id/fragment_item_list"
             app:launchSingleTop="true"
             app:popUpTo="@+id/fragment_item_list"
@@ -133,7 +128,6 @@
 
     <action
             android:id="@+id/action_to_welcome"
-            app:clearTask="true"
             app:destination="@id/fragment_welcome"
             app:launchSingleTop="true"
             app:popUpTo="@+id/fragment_welcome"

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -6,6 +6,7 @@ import android.hardware.fingerprint.FingerprintManager
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
+import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.FingerprintAuthAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.extensions.assertLastValue
@@ -108,7 +109,7 @@ class LockedPresenterTest {
     @Test
     fun `handle success authentication callback`() {
         lockedStore.onAuth.onNext(FingerprintAuthAction.OnAuthentication(AuthCallback.OnAuth))
-        dispatcherObserver.assertLastValue(RouteAction.ItemList)
+        dispatcherObserver.assertLastValue(DataStoreAction.Unlock)
     }
 
     @Test
@@ -121,7 +122,7 @@ class LockedPresenterTest {
     @Test
     fun `handle unlock confirmed true`() {
         view.unlockConfirmedStub.onNext(true)
-        dispatcherObserver.assertLastValue(RouteAction.ItemList)
+        dispatcherObserver.assertLastValue(DataStoreAction.Unlock)
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -127,6 +127,6 @@ class LockedPresenterTest {
     @Test
     fun `handle unlock confirmed false`() {
         view.unlockConfirmedStub.onNext(false)
-        dispatcherObserver.assertLastValue(RouteAction.LockScreen)
+        Assert.assertEquals(0, dispatcherObserver.valueCount())
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -87,7 +87,7 @@ class DataStoreTest : DisposingTest() {
 
         val id = "lkjhkj"
         dispatcher.dispatch(DataStoreAction.Touch(id))
-
+        sleep(100)
         Mockito.verify(support.storage).touch(id)
         sleep(100)
         Mockito.verify(support.storage).list()

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -13,11 +13,10 @@ import mozilla.appservices.logins.SyncUnlockInfo
 import mozilla.components.service.fxa.OAuthScopedKey
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.DataStoreAction
-import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.mocks.MockDataStoreSupport
-import mozilla.lockbox.model.SyncCredentials
+import mozilla.lockbox.model.FxASyncCredentials
 import mozilla.lockbox.store.DataStore.State
 import mozilla.lockbox.support.FxAOauthInfo
 import org.junit.Assert
@@ -101,21 +100,7 @@ class DataStoreTest : DisposingTest() {
         dispatcher.dispatch(DataStoreAction.Reset)
         sleep(100)
 
-        verify(support.storage).reset()
-
-        listObserver.assertLastValue(emptyList())
-        stateObserver.assertLastValue(DataStore.State.Unprepared)
-    }
-
-    @Test
-    fun testUserReset() {
-        dispatcher.dispatch(DataStoreAction.Unlock)
-        sleep(100)
-
-        dispatcher.dispatch(LifecycleAction.UserReset)
-        sleep(100)
-
-        verify(support.storage).reset()
+        Mockito.verify(support.storage).reset()
 
         listObserver.assertLastValue(emptyList())
         stateObserver.assertLastValue(DataStore.State.Unprepared)
@@ -153,10 +138,11 @@ class DataStoreTest : DisposingTest() {
             override val keys: Map<String, OAuthScopedKey>? = mapOf(Pair(scope, scopedKey))
             override val scopes: List<String> = listOf(scope)
         }
-        val syncCredentials = SyncCredentials(
+        val syncCredentials = FxASyncCredentials(
             oauthInfo,
             tokenServerURL,
-            scope
+            scope,
+            false
         )
         dispatcher.dispatch(DataStoreAction.UpdateCredentials(
             syncCredentials

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -69,10 +69,7 @@ class DataStoreTest : DisposingTest() {
 
         stateObserver.apply {
             // TODO: figure out why the initialized state isn't here?
-            assertValueCount(3)
-            assertValueAt(0, State.Unprepared)
-            assertValueAt(1, State.Unlocked)
-            assertValueAt(2, State.Locked)
+            assertValues(State.Unprepared, State.Unlocking, State.Unlocked, State.Locked)
         }
         listObserver.apply {
             val results = values()

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -23,8 +23,7 @@ import mozilla.lockbox.support.FxAOauthInfo
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.clearInvocations
-import org.mockito.Mockito.verify
+import org.mockito.Mockito
 import java.lang.Thread.sleep
 
 @ExperimentalCoroutinesApi
@@ -84,14 +83,14 @@ class DataStoreTest : DisposingTest() {
     fun testTouch() {
         dispatcher.dispatch(DataStoreAction.Unlock)
         sleep(100)
-        clearInvocations(support.storage)
+        Mockito.clearInvocations(support.storage)
 
         val id = "lkjhkj"
         dispatcher.dispatch(DataStoreAction.Touch(id))
 
-        verify(support.storage).touch(id)
+        Mockito.verify(support.storage).touch(id)
         sleep(100)
-        verify(support.storage).list()
+        Mockito.verify(support.storage).list()
     }
 
     @Test
@@ -138,7 +137,7 @@ class DataStoreTest : DisposingTest() {
 
         stateObserver.assertLastValue(State.Unlocked)
         subject.resetSupport(MockDataStoreSupport())
-        verify(newSupport.storage).reset()
+        Mockito.verify(newSupport.storage).reset()
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.kotlin_version = '1.3.0'
     ext.android_components_version = '0.33.0'
     ext.lifecycle_version = '1.1.1'
-    ext.navigation_version = '1.0.0-alpha07'
+    ext.navigation_version = '1.0.0-alpha08'
     ext.rxbinding_version = '2.2.0'
     ext.coroutine_version = '1.0.1'
 


### PR DESCRIPTION
Fixes #144
Fixed #239
Depends on #22
Depends on #68
Replaces #169 

## Testing and Review Notes

_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_


## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
