### PR TITLE
Add l10n.toml to set up config for l10n, move non-localizable strings…

### DIFF
--- a/app/src/main/res/values/non_localizable_strings.xml
+++ b/app/src/main/res/values/non_localizable_strings.xml
@@ -1,0 +1,11 @@
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name" translatable="false">Firefox Lockbox</string>
+    <string name="app_label" translatable="false">Lockbox</string>
+    <string name="telemetry_server_endpoint" translatable="false">https://incoming.telemetry.mozilla.org</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,8 +5,6 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name">Firefox Lockbox</string>
-    <string name="app_label">Lockbox</string>
     <string name="app_tagline">Take your passwords everywhere.</string>
 
     <string name="welcome_start_btn">Get Started</string>
@@ -33,7 +31,6 @@
     <string name="hint_password">Password</string>
     <string name="toast_username_copied">Username copied</string>
     <string name="toast_password_copied">Password copied</string>
-    <string name="telemetry_server_endpoint" translatable="false">https://incoming.telemetry.mozilla.org</string>
     <string name="learn_to_edit_entry">Learn how to edit this entry</string>
 
     <string name="configuration_title">Configuration</string>

--- a/l10n.toml
+++ b/l10n.toml
@@ -1,0 +1,10 @@
+
+basepath = "."
+
+locales = [
+]
+[env]
+
+[[paths]]
+  reference = "app/src/main/res/values/strings.xml"
+  l10n = "{l10n_base}/app/src/main/res/values-{android_locale}/strings.xml"

--- a/l10n.toml
+++ b/l10n.toml
@@ -7,4 +7,4 @@ locales = [
 
 [[paths]]
   reference = "app/src/main/res/values/strings.xml"
-  l10n = "{l10n_base}/app/src/main/res/values-{android_locale}/strings.xml"
+  l10n = "app/src/main/res/values-{android_locale}/strings.xml"


### PR DESCRIPTION
… out of strings.xml

The branding of Firefox Lockbox shouldn't be translated or transliterated, let's
make it translatable="false" and move it to a dedicated file.

Fixes #???

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

Connected to #???

_(Optional: other issues or pull requests related to this, but merging should not close it)_

## Testing and Review Notes

_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_


## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
