### PR TITLE
add telemetry events for views and copy actions

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/ClipboardAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/ClipboardAction.kt
@@ -6,9 +6,10 @@
 
 package mozilla.lockbox.action
 
-import mozilla.lockbox.flux.Action
-
-sealed class ClipboardAction : Action {
-    data class CopyUsername(val username: String) : ClipboardAction()
-    data class CopyPassword(val password: String) : ClipboardAction()
+sealed class ClipboardAction(
+    override val eventMethod: TelemetryEventMethod,
+    override val eventObject: TelemetryEventObject
+) : TelemetryAction {
+    data class CopyUsername(val username: String) : ClipboardAction(TelemetryEventMethod.tap, TelemetryEventObject.entry_copy_username_button)
+    data class CopyPassword(val password: String) : ClipboardAction(TelemetryEventMethod.tap, TelemetryEventObject.entry_copy_password_button)
 }

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -9,29 +9,32 @@ package mozilla.lockbox.action
 import android.support.annotation.StringRes
 import mozilla.lockbox.flux.Action
 
-sealed class RouteAction : Action {
-    object Welcome : RouteAction()
-    object ItemList : RouteAction()
-    object Login : RouteAction()
-    object SettingList : RouteAction()
-    object AccountSetting : RouteAction()
-    object AutoLockSetting : RouteAction()
-    object Back : RouteAction()
-    object LockScreen : RouteAction()
-    object Filter : RouteAction()
-    data class ItemDetail(val id: String) : RouteAction()
-    data class OpenWebsite(val url: String) : RouteAction()
-    data class SystemSetting(val setting: SettingIntent) : RouteAction()
+sealed class RouteAction(
+    override val eventMethod: TelemetryEventMethod,
+    override val eventObject: TelemetryEventObject
+) : TelemetryAction {
+    object Welcome : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.login_welcome)
+    object ItemList : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.entry_list)
+    object Login : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.login_fxa)
+    object SettingList : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_list)
+    object AccountSetting : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_account)
+    object AutoLockSetting : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_autolock)
+    object Back : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
+    object LockScreen : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.lock_screen)
+    object Filter : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.filter)
+    data class ItemDetail(val id: String) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.entry_detail)
+    data class OpenWebsite(val url: String) : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.open_in_browser)
+    data class SystemSetting(val setting: SettingIntent) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_system)
 
     sealed class Dialog(
         val positiveButtonAction: Action? = null,
         val negativeButtonAction: Action? = null
-    ) : RouteAction() {
+    ) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.dialog) {
         object SecurityDisclaimer : Dialog(RouteAction.SystemSetting(SettingIntent.Security))
         object UnlinkDisclaimer : Dialog(LifecycleAction.UserReset)
     }
 
-    sealed class DialogFragment(@StringRes val dialogTitle: Int, @StringRes val dialogSubtitle: Int? = null) : RouteAction() {
+    sealed class DialogFragment(@StringRes val dialogTitle: Int, @StringRes val dialogSubtitle: Int? = null) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.dialog) {
         class FingerprintDialog(@StringRes title: Int, @StringRes subtitle: Int? = null) :
             DialogFragment(dialogTitle = title, dialogSubtitle = subtitle)
     }

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -19,7 +19,6 @@ sealed class RouteAction(
     object SettingList : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_list)
     object AccountSetting : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_account)
     object AutoLockSetting : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_autolock)
-    object Back : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
     object LockScreen : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.lock_screen)
     object Filter : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.filter)
     data class ItemDetail(val id: String) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.entry_detail)

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -64,10 +64,16 @@ enum class TelemetryEventObject {
     settings_faq,
     settings_provide_feedback,
     settings_get_support,
+    settings_system,
     login_welcome,
     login_fxa,
     login_onboarding_confirmation,
     login_learn_more,
     autofill_onboarding,
-    autofill
+    autofill,
+    lock_screen,
+    open_in_browser,
+    filter,
+    back,
+    dialog
 }

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -13,6 +13,8 @@ import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.ReplaySubject
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.LifecycleAction
+import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.action.ClipboardAction
 import mozilla.lockbox.action.TelemetryAction
 import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.extensions.assertLastValueMatches
@@ -75,6 +77,17 @@ class TelemetryStoreTest : DisposingTest() {
             it.toJSON() == action.createEvent().toJSON()
         }
         action = LifecycleAction.Background
+        dispatcher.dispatch(action)
+        eventsObserver.assertLastValueMatches {
+            it.toJSON() == action.createEvent().toJSON()
+        }
+        action = RouteAction.ItemList
+        dispatcher.dispatch(action)
+        eventsObserver.assertLastValueMatches {
+            it.toJSON() == action.createEvent().toJSON()
+        }
+        val testUsername = "lockie"
+        action = ClipboardAction.CopyUsername(testUsername)
         dispatcher.dispatch(action)
         eventsObserver.assertLastValueMatches {
             it.toJSON() == action.createEvent().toJSON()

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -20,6 +20,7 @@ import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.extensions.assertLastValueMatches
 import mozilla.lockbox.flux.Dispatcher
 import org.junit.Test
+import org.junit.Assert
 import org.junit.runner.RunWith
 import org.mozilla.telemetry.event.TelemetryEvent
 import org.robolectric.RobolectricTestRunner
@@ -81,6 +82,7 @@ class TelemetryStoreTest : DisposingTest() {
         eventsObserver.assertLastValueMatches {
             it.toJSON() == action.createEvent().toJSON()
         }
+        uploadObserver.assertLastValue(1)
         action = RouteAction.ItemList
         dispatcher.dispatch(action)
         eventsObserver.assertLastValueMatches {
@@ -89,9 +91,18 @@ class TelemetryStoreTest : DisposingTest() {
         val testUsername = "lockie"
         action = ClipboardAction.CopyUsername(testUsername)
         dispatcher.dispatch(action)
+        var eventJSON = action.createEvent().toJSON()
         eventsObserver.assertLastValueMatches {
-            it.toJSON() == action.createEvent().toJSON()
+            it.toJSON() == eventJSON
         }
-        uploadObserver.assertLastValue(1)
+        Assert.assertFalse("event does not contain the actual username", eventJSON.contains(testUsername))
+        val testPassword = "lockie123"
+        action = ClipboardAction.CopyPassword(testPassword)
+        dispatcher.dispatch(action)
+        eventJSON = action.createEvent().toJSON()
+        eventsObserver.assertLastValueMatches {
+            it.toJSON() == eventJSON
+        }
+        Assert.assertFalse("event does not contain the actual password", eventJSON.contains(testPassword))
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -88,21 +88,19 @@ class TelemetryStoreTest : DisposingTest() {
         eventsObserver.assertLastValueMatches {
             it.toJSON() == action.createEvent().toJSON()
         }
+    }
+
+    @Test
+    fun testNoLeaks () {
         val testUsername = "lockie"
-        action = ClipboardAction.CopyUsername(testUsername)
+        val testPassword = "lockie123"
+        var action: TelemetryAction = ClipboardAction.CopyUsername(testUsername)
         dispatcher.dispatch(action)
         var eventJSON = action.createEvent().toJSON()
-        eventsObserver.assertLastValueMatches {
-            it.toJSON() == eventJSON
-        }
         Assert.assertFalse("event does not contain the actual username", eventJSON.contains(testUsername))
-        val testPassword = "lockie123"
         action = ClipboardAction.CopyPassword(testPassword)
         dispatcher.dispatch(action)
         eventJSON = action.createEvent().toJSON()
-        eventsObserver.assertLastValueMatches {
-            it.toJSON() == eventJSON
-        }
         Assert.assertFalse("event does not contain the actual password", eventJSON.contains(testPassword))
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -91,7 +91,7 @@ class TelemetryStoreTest : DisposingTest() {
     }
 
     @Test
-    fun testNoLeaks () {
+    fun testNoLeaks() {
         val testUsername = "lockie"
         val testPassword = "lockie123"
         var action: TelemetryAction = ClipboardAction.CopyUsername(testUsername)


### PR DESCRIPTION
This implements a grab bag of telemetry events for RouteAction and ClipboardAction. Can do more but wanted some feedback on whether this is the right approach (questions at the end)

Fixes https://github.com/mozilla-lockbox/lockbox-android/issues/14 and fixes https://github.com/mozilla-lockbox/lockbox-android/issues/117 except for the reveal password bit which [needs an action still](https://github.com/mozilla-lockbox/lockbox-android/issues/205)

Connected to https://github.com/mozilla-lockbox/lockbox-android/issues/120, connected to https://github.com/mozilla-lockbox/lockbox-android/issues/121

## Testing and Review Notes

I made changes to https://github.com/mozilla-lockbox/lockbox-android/blob/e89a898b8ee3a1eaac79060e542bd2ac8acc2e24/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt#L20 in order to print the events to the console to verify that they are working, like:

```kotlin
open fun createEvent(category: String = "action"): TelemetryEvent {
    val evt = TelemetryEvent.create(
            category,
            eventMethod.name,
            eventObject.name,
            value
    )
    extras?.forEach { ex -> evt.extra(ex.key, ex.value.toString()) }
    println("the telemetry event method is $eventMethod") // I add this to test
    println("the telemetry event object is $eventObject") // I add this to test
    return evt
}
```

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] add unit tests
  I added some meager tests as copypasta from previous examples but there may be more to do there, guidance appreciated
- [ ] route actions decision = make them all telemetry means leave this as is
- [ ] some cleanup needed


 Also, although I've verified that this way of doing it works (thanks Matt) I'm not sure its the best or only way. For example, I don't know how to make the `EventMethod` and `EventObject` parameters optional (e.g. in `RouteAction.kt`) so as to not record events for the properties we don't really care about, e.g. we don't really need an event for the back button on https://github.com/mozilla-lockbox/lockbox-android/blob/e89a898b8ee3a1eaac79060e542bd2ac8acc2e24/app/src/main/java/mozilla/lockbox/action/RouteAction.kt#L19 
