### PR TITLE
Removing navToolbar

### DIFF
--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -20,7 +20,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            card_view:layout_constraintTop_toBottomOf="@id/navToolbar">
+            card_view:layout_constraintTop_toBottomOf="@id/toolbar">
 
         <android.support.constraint.ConstraintLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Fixes: `toolbar` was incorrectly renamed to `navToolbar` during a rebase of #7, causing the backable toolbar to disappear from the detail view.
