### PR TITLE
Hide the autofill setting until its actually built

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
@@ -102,7 +102,7 @@ class SettingPresenter(
                 detailTextDriver = settingStore.autoLockTime.map { it.stringValue },
                 clickListener = autoLockTimeClickListener
             ),
-            /* TODO: enable Autofill setting once it's actually implemented
+            /* TODO: enable Autofill setting and increase supportIndex once it's actually implemented
             ToggleSettingConfiguration(
                 title = R.string.autofill,
                 subtitle = R.string.autofill_summary,
@@ -125,7 +125,7 @@ class SettingPresenter(
             )
         )
 
-        var supportIndex = 2
+        var supportIndex = 1
 
         if (fingerprintStore.isFingerprintAuthAvailable) {
             settings = listOf(

--- a/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
@@ -6,7 +6,6 @@
 
 package mozilla.lockbox.presenter
 
-import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.addTo
@@ -103,6 +102,7 @@ class SettingPresenter(
                 detailTextDriver = settingStore.autoLockTime.map { it.stringValue },
                 clickListener = autoLockTimeClickListener
             ),
+            /* TODO: enable Autofill setting once it's actually implemented
             ToggleSettingConfiguration(
                 title = R.string.autofill,
                 subtitle = R.string.autofill_summary,
@@ -110,6 +110,7 @@ class SettingPresenter(
                 toggleDriver = Observable.just(true),
                 toggleObserver = autoFillObserver
             ),
+            */
             ToggleSettingConfiguration(
                 title = R.string.send_usage_data,
                 subtitle = R.string.send_usage_data_summary,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,8 +38,8 @@
     <string name="learn_more">Learn more</string>
     <string name="auto_lock">Auto lock</string>
     <string name="unlock">Unlock with fingerprint</string>
-    <string name="autofill">Autofill</string>
-    <string name="autofill_summary">Let Firefox Lockbox fill in logins for you</string>
+    <!-- <string name="autofill">Autofill</string> -->
+    <!-- <string name="autofill_summary">Let Firefox Lockbox fill in logins for you</string> -->
     <string name="send_usage_data">Send usage data</string>
     <string name="send_usage_data_summary">Mozilla strives to only collect what we need to provide and improve Firefox for everyone. </string>
     <string name="fingerprint_dialog_title">Unlock Firefox Lockbox</string>
@@ -93,7 +93,7 @@
     <string name="profile_image_content_description">Firefox Account Profile Image</string>
     <string name="auto_lock_description">Auto lock setting</string>
     <string name="app_version_description">Application version number</string>
-    <string name="autofill_description">Application autofill setting</string>
+    <!-- <string name="autofill_description">Application autofill setting</string> -->
     <string name="fingerprint_description">Enable fingerprint setting</string>
     <string name="learn_more_description">Learn more about sending usage data</string>
 </resources>

--- a/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
@@ -64,6 +64,7 @@ class ListAdapterTestHelper {
                 detailTextDriver = textDriverFake,
                 clickListener = textClicksConsumerFake
             ),
+            /* TODO: enable Autofill setting once it's actually implemented
             ToggleSettingConfiguration(
                 title = R.string.autofill,
                 subtitle = R.string.autofill_summary,
@@ -71,6 +72,7 @@ class ListAdapterTestHelper {
                 toggleDriver = toggleDriverFake,
                 toggleObserver = toggleConsumerFake
             ),
+            */
             ToggleSettingConfiguration(
                 title = R.string.send_usage_data,
                 subtitle = R.string.send_usage_data_summary,

--- a/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
@@ -99,13 +99,13 @@ class SettingPresenterTest {
         assertEquals(view.settingItem!![1].title, expectedSettings[1].title)
         assertEquals(view.settingItem!![2].title, expectedSettings[2].title)
         assertEquals(view.settingItem!![3].title, expectedSettings[3].title)
-        assertEquals(view.settingItem!![4].title, expectedSettings[4].title)
+        // assertEquals(view.settingItem!![4].title, expectedSettings[4].title)
 
         assertEquals(view.sectionsItem!![0].title, expectedSections[0].title)
         assertEquals(view.sectionsItem!![1].title, expectedSections[1].title)
 
         assertEquals(view.sectionsItem!![0].firstPosition, expectedSections[0].firstPosition)
-        assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
+        // assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
     }
 
     @Test
@@ -123,13 +123,13 @@ class SettingPresenterTest {
         assertEquals(view.settingItem!![0].title, expectedSettings[0].title)
         assertEquals(view.settingItem!![1].title, expectedSettings[1].title)
         assertEquals(view.settingItem!![2].title, expectedSettings[2].title)
-        assertEquals(view.settingItem!![3].title, expectedSettings[3].title)
+        // assertEquals(view.settingItem!![3].title, expectedSettings[3].title)
 
         assertEquals(view.sectionsItem!![0].title, expectedSections[0].title)
         assertEquals(view.sectionsItem!![1].title, expectedSections[1].title)
 
         assertEquals(view.sectionsItem!![0].firstPosition, expectedSections[0].firstPosition)
-        assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
+        // assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
     }
 
     @Test
@@ -215,7 +215,7 @@ class SettingPresenterTest {
         Mockito.`when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
         subject.onResume()
 
-        (view.settingItem!![2] as ToggleSettingConfiguration).toggleObserver.accept(false)
+        (view.settingItem!![1] as ToggleSettingConfiguration).toggleObserver.accept(false)
 
         val dispatchedAction = dispatcherObserver.values().last() as SettingAction.SendUsageData
         Assert.assertFalse(dispatchedAction.sendUsageData)


### PR DESCRIPTION
Fixes #263

Will be re-implemented at #56 

## Testing and Review Notes

- open settings screen
- observe the "Autofill..." setting title, description, and toggle are not there

## Screenshots or Videos

Before:
![screen shot 2018-12-17 at 4 44 11 pm](https://user-images.githubusercontent.com/49511/50122702-08694500-021b-11e9-82cc-26924a940e70.png)

After:
![screen shot 2018-12-17 at 4 47 25 pm](https://user-images.githubusercontent.com/49511/50122822-89284100-021b-11e9-9e3d-d2f9e61c4519.png)


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
