### PR TITLE
Update unlock screen to match designs

### DIFF
--- a/app/src/main/res/drawable/ic_icon_lock.xml
+++ b/app/src/main/res/drawable/ic_icon_lock.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="40dp"
+    android:viewportWidth="32"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M10,10a6,6 0,0 1,12 0v6L10,16v-6zM14.875,26.654l-1.45,6a1.08,1.08 0,0 0,1.044 1.348h3.055a1.086,1.086 0,0 0,1.044 -1.348l-1.45,-5.998a3.201,3.201 0,1 0,-2.243 -0.002zM6,16v-6C6,4.477 10.477,0 16,0s10,4.477 10,10v6h2a4,4 0,0 1,4 4v16a4,4 0,0 1,-4 4L4,40a4,4 0,0 1,-4 -4L0,20a4,4 0,0 1,4 -4h2z"
+      android:strokeAlpha="0.6"
+      android:fillColor="#FFF"
+      android:fillType="evenOdd"
+      android:fillAlpha="0.6"/>
+</vector>

--- a/app/src/main/res/layout/fragment_locked.xml
+++ b/app/src/main/res/layout/fragment_locked.xml
@@ -16,9 +16,21 @@
         layout="@layout/include_nessie"
         tools:ignore="MissingConstraints" />
 
+    <ImageView
+            android:id="@+id/iconLock"
+            android:layout_width="32dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:background="@android:color/transparent"
+            app:srcCompat="@drawable/ic_icon_lock"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/unlockButton"
+            android:layout_marginBottom="16dp"/>
     <Button
             android:id="@+id/unlockButton"
-            android:layout_width="match_constraint"
+            android:layout_width="0dp"
             android:layout_height="36dp"
             android:layout_marginBottom="8dp"
             android:layout_marginEnd="90dp"
@@ -34,6 +46,5 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>
-
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_locked.xml
+++ b/app/src/main/res/layout/fragment_locked.xml
@@ -28,7 +28,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintBottom_toTopOf="@+id/unlockButton"
-            android:layout_marginBottom="16dp"/>
+            android:layout_marginBottom="16dp"
+            android:contentDescription="@string/lock_icon_description"/>
     <Button
             android:id="@+id/unlockButton"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_locked.xml
+++ b/app/src/main/res/layout/fragment_locked.xml
@@ -17,18 +17,23 @@
         tools:ignore="MissingConstraints" />
 
     <Button
-        android:id="@+id/unlockButton"
-        android:layout_width="86dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="100dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="20dp"
-        android:text="@string/placeholder_unlock_button"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/include" />
+            android:id="@+id/unlockButton"
+            android:layout_width="match_constraint"
+            android:layout_height="36dp"
+            android:layout_marginBottom="8dp"
+            android:layout_marginEnd="90dp"
+            android:layout_marginStart="90dp"
+            android:layout_marginTop="225dp"
+            android:background="@drawable/rounded_corner_selector"
+            android:letterSpacing="0.09"
+            android:lineSpacingExtra="2sp"
+            android:text="@string/placeholder_unlock_button"
+            android:textColor="@color/colorPrimary"
+            android:textStyle="normal"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"/>
 
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_locked.xml
+++ b/app/src/main/res/layout/fragment_locked.xml
@@ -41,7 +41,7 @@
             android:background="@drawable/rounded_corner_selector"
             android:letterSpacing="0.09"
             android:lineSpacingExtra="2sp"
-            android:text="@string/placeholder_unlock_button"
+            android:text="@string/unlock_button"
             android:textColor="@color/colorPrimary"
             android:textStyle="normal"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_locked.xml
+++ b/app/src/main/res/layout/fragment_locked.xml
@@ -10,7 +10,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    style="@style/WelcomeScreen">
 
     <include android:id="@+id/include"
         layout="@layout/include_nessie"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,5 +95,6 @@
     <string name="app_version_description">Application version number</string>
     <!-- <string name="autofill_description">Application autofill setting</string> -->
     <string name="fingerprint_description">Enable fingerprint setting</string>
+    <string name="lock_icon_description">Lock icon image</string>
     <string name="learn_more_description">Learn more about sending usage data</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="sort_menu_az">Alphabetically</string>
     <string name="sort_menu_recent">Recently Used</string>
 
-    <string name="placeholder_unlock_button">Unlock Firefox Lockbox</string>
+    <string name="placeholder_unlock_button">Unlock</string>
     <string name="lock_now">Lock Now</string>
     <string name="all_entries_a_z">All entries (A-Z)</string>
     <string name="all_entries_recent">All entries (Recent)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="sort_menu_az">Alphabetically</string>
     <string name="sort_menu_recent">Recently Used</string>
 
-    <string name="placeholder_unlock_button">Unlock</string>
+    <string name="unlock_button">Unlock</string>
     <string name="lock_now">Lock Now</string>
     <string name="all_entries_a_z">All entries (A-Z)</string>
     <string name="all_entries_recent">All entries (Recent)</string>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.kotlin_version = '1.3.0'
     ext.android_components_version = '0.33.0'
     ext.lifecycle_version = '1.1.1'
-    ext.navigation_version = '1.0.0-alpha08'
+    ext.navigation_version = '1.0.0-alpha09'
     ext.rxbinding_version = '2.2.0'
     ext.coroutine_version = '1.0.1'
 


### PR DESCRIPTION
Implemented changes to match the design:

https://app.zeplin.io/project/5b6895bfe4af825140aa8dbc/screen/5b6915ce008a822d0c4bc515

- added lock icon above unlock button
- changed unlock button to match styles
- changed overall fragment to inherit welcome styles (e.g.: grey background)

Related to #54 

## Testing and Review Notes

- sign in to app
- from the nav drawer, "Lock Now"
- observe the unlock screen

## Screenshots or Videos

![image](https://user-images.githubusercontent.com/49511/50172714-d99ead80-02b2-11e9-8143-a4fbdedeca19.png)


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [x] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
