### PR TITLE
Capture OAuth Redirect before it can be Displayed

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -35,7 +35,7 @@ class FxALoginPresenter(
     override fun onViewReady() {
         view.webViewObserver = Consumer { url ->
             url?.let {
-                if (url.startsWith(Constant.FxA.redirectUri)) {
+                if (isRedirectUri(it)) {
                     dispatcher.dispatch(AccountAction.OauthRedirect(url))
                 }
             }

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -30,6 +30,8 @@ class FxALoginPresenter(
     private val dispatcher: Dispatcher = Dispatcher.shared,
     private val accountStore: AccountStore = AccountStore.shared
 ) : Presenter() {
+    fun isRedirectUri(uri: String?) : Boolean = uri?.startsWith(Constant.FxA.redirectUri) ?: false
+
     override fun onViewReady() {
         view.webViewObserver = Consumer { url ->
             url?.let {

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -30,7 +30,7 @@ class FxALoginPresenter(
     private val dispatcher: Dispatcher = Dispatcher.shared,
     private val accountStore: AccountStore = AccountStore.shared
 ) : Presenter() {
-    fun isRedirectUri(uri: String?) : Boolean = uri?.startsWith(Constant.FxA.redirectUri) ?: false
+    fun isRedirectUri(uri: String?): Boolean = uri?.startsWith(Constant.FxA.redirectUri) ?: false
 
     override fun onViewReady() {
         view.webViewObserver = Consumer { url ->

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -7,6 +7,7 @@
 package mozilla.lockbox.view
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -17,7 +18,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.Observable
-import io.reactivex.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_fxa_login.*
 import kotlinx.android.synthetic.main.fragment_fxa_login.view.*
 import kotlinx.android.synthetic.main.include_backable.view.*
@@ -27,7 +27,7 @@ import mozilla.lockbox.presenter.FxALoginView
 import mozilla.lockbox.support.isDebug
 
 class FxALoginFragment : BackableFragment(), FxALoginView {
-    override var webViewObserver: Consumer<String?>? = null
+    override var webViewRedirect: ((url: Uri?) -> Boolean) = { _ -> false }
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -53,14 +53,8 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
 
     override fun loadURL(url: String) {
         webView.webViewClient = object : WebViewClient() {
-            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-                val url = request?.url.toString() ?: null
-                if ((presenter as FxALoginPresenter).isRedirectUri(url)) {
-                    webViewObserver?.accept(url)
-                    return true
-                }
-                return false
-            }
+            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean =
+                webViewRedirect(request?.url)
         }
         webView.loadUrl(url)
     }

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -19,6 +19,7 @@ import android.webkit.WebViewClient
 import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
+import kotlinx.android.synthetic.main.fragment_fxa_login.*
 import kotlinx.android.synthetic.main.fragment_fxa_login.view.*
 import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.R

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -19,7 +19,6 @@ import android.webkit.WebViewClient
 import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
-import kotlinx.android.synthetic.main.fragment_fxa_login.*
 import kotlinx.android.synthetic.main.fragment_fxa_login.view.*
 import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.R

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -13,6 +13,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.CookieManager
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.jakewharton.rxbinding2.view.clicks
@@ -53,10 +54,13 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
 
     override fun loadURL(url: String) {
         webView.webViewClient = object : WebViewClient() {
-            override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                webViewObserver?.accept(url)
-
-                super.onPageStarted(view, url, favicon)
+            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+                val url = request?.url.toString() ?: null
+                if ((presenter as FxALoginPresenter).isRedirectUri(url)) {
+                    webViewObserver?.accept(url)
+                    return true
+                }
+                return false
             }
         }
         webView.loadUrl(url)

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -7,7 +7,6 @@
 package mozilla.lockbox.view
 
 import android.annotation.SuppressLint
-import android.graphics.Bitmap
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View

--- a/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
@@ -38,7 +38,7 @@ class FxALoginPresenterTest : DisposingTest() {
     class FakeFxALoginView(
         val compositeDisposable: CompositeDisposable
     ) : FxALoginView {
-        val webViewRedirects = PublishSubject.create<Uri>()
+        val webViewRedirectTo = PublishSubject.create<Uri>()
         val webViewOverride = PublishSubject.create<Boolean?>()
         var loadedURL: String? = null
         override var webViewRedirect: (url: Uri?) -> Boolean = { _ -> false }
@@ -49,7 +49,7 @@ class FxALoginPresenterTest : DisposingTest() {
         override var skipFxAClicks: Observable<Unit> = PublishSubject.create<Unit>()
 
         init {
-            webViewRedirects.subscribe {
+            webViewRedirectTo.subscribe {
                 webViewOverride.onNext(webViewRedirect(it))
             }.addTo(compositeDisposable)
         }
@@ -97,7 +97,7 @@ class FxALoginPresenterTest : DisposingTest() {
     @Test
     fun `onViewReady, when the webview redirects to a URL starting with the expected redirect`() {
         val url = Uri.parse(Constant.FxA.redirectUri + "?moz_fake")
-        view.webViewRedirects.onNext(url)
+        view.webViewRedirectTo.onNext(url)
 
         val redirectAction = dispatcherObserver.values().first() as AccountAction.OauthRedirect
         Assert.assertEquals(url.toString(), redirectAction.url)
@@ -106,7 +106,7 @@ class FxALoginPresenterTest : DisposingTest() {
     @Test
     fun `onViewReady, when the webview redirects to a URL not starting with the expected redirect`() {
         val url = Uri.parse("https://www.mozilla.org")
-        view.webViewRedirects.onNext(url)
+        view.webViewRedirectTo.onNext(url)
 
         dispatcherObserver.assertEmpty()
     }

--- a/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
@@ -70,6 +70,16 @@ class FxALoginPresenterTest {
     }
 
     @Test
+    fun `isRedirectURI is working as expected`() {
+        var url: String? = null
+        Assert.assertFalse(subject.isRedirectUri(url))
+        url = "https://www.mozilla.org/"
+        Assert.assertFalse(subject.isRedirectUri(url))
+        url = Constant.FxA.redirectUri + "?moz_fake"
+        Assert.assertTrue(subject.isRedirectUri(url))
+    }
+
+    @Test
     fun `onViewReady, when the accountStore pushes a new loginURL`() {
         val url = "www.mozilla.org"
         loginURLSubject.onNext(url)
@@ -79,7 +89,7 @@ class FxALoginPresenterTest {
 
     @Test
     fun `onViewReady, when the webview redirects to a URL starting with the expected redirect`() {
-        val url = Constant.FxA.redirectUri + "/moz_fake"
+        val url = Constant.FxA.redirectUri + "?moz_fake"
         view.webViewRedirects.onNext(url)
 
         val redirectAction = dispatcherObserver.values().first() as AccountAction.OauthRedirect

--- a/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
@@ -6,11 +6,14 @@
 
 package mozilla.lockbox.presenter
 
+import android.net.Uri
 import io.reactivex.Observable
-import io.reactivex.functions.Consumer
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.observers.TestObserver
+import io.reactivex.rxkotlin.addTo
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.flux.Action
@@ -31,24 +34,28 @@ import org.mockito.Mockito.`when` as whenCalled
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @PrepareForTest(AccountStore::class)
-class FxALoginPresenterTest {
-    class FakeFxALoginView : FxALoginView {
-        val webViewRedirects = PublishSubject.create<String>()
+class FxALoginPresenterTest : DisposingTest() {
+    class FakeFxALoginView(
+        val compositeDisposable: CompositeDisposable
+    ) : FxALoginView {
+        val webViewRedirects = PublishSubject.create<Uri>()
+        val webViewOverride = PublishSubject.create<Boolean?>()
         var loadedURL: String? = null
-        override var webViewObserver: Consumer<String?>?
-            get() = TODO("not implemented")
-            set(value) {
-                this.webViewRedirects.subscribe(value)
-            }
-
+        override var webViewRedirect: (url: Uri?) -> Boolean = { _ -> false }
         override fun loadURL(url: String) {
             loadedURL = url
         }
 
         override var skipFxAClicks: Observable<Unit> = PublishSubject.create<Unit>()
+
+        init {
+            webViewRedirects.subscribe {
+                webViewOverride.onNext(webViewRedirect(it))
+            }.addTo(compositeDisposable)
+        }
     }
 
-    val view = FakeFxALoginView()
+    val view = FakeFxALoginView(disposer)
 
     @Mock
     val accountStore = PowerMockito.mock(AccountStore::class.java)
@@ -89,16 +96,16 @@ class FxALoginPresenterTest {
 
     @Test
     fun `onViewReady, when the webview redirects to a URL starting with the expected redirect`() {
-        val url = Constant.FxA.redirectUri + "?moz_fake"
+        val url = Uri.parse(Constant.FxA.redirectUri + "?moz_fake")
         view.webViewRedirects.onNext(url)
 
         val redirectAction = dispatcherObserver.values().first() as AccountAction.OauthRedirect
-        Assert.assertEquals(url, redirectAction.url)
+        Assert.assertEquals(url.toString(), redirectAction.url)
     }
 
     @Test
     fun `onViewReady, when the webview redirects to a URL not starting with the expected redirect`() {
-        val url = "www.mozilla.org"
+        val url = Uri.parse("https://www.mozilla.org")
         view.webViewRedirects.onNext(url)
 
         dispatcherObserver.assertEmpty()


### PR DESCRIPTION
This change properly captures the OAuth redirect URI and instructs the webView that the application will handle it rather than letting the default rendering occur.

Fixes #296

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

## Testing and Review Notes

**Prerequisites**

* not signed into FxA in Lockbox

**Steps**

* Open Lockbox
* Click "Get Started"
* Complete FXA sign-in/sign-up flow

_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_


## Screenshots or Videos

![no-show-redirect](https://user-images.githubusercontent.com/757401/50295975-9f5e1900-0436-11e9-9925-d1e93c305eb0.gif)


## To Do

- ~add “WIP” to the PR title if pushing up but not complete nor ready for review~
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- ~check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI~