### PR TITLE
workaround loginsstorage exception on first-time login

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -16,7 +16,6 @@ import br.com.concretesolutions.kappuccino.custom.intent.IntentMatcherInteractio
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
-import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.accountSettingScreen
 import mozilla.lockbox.robots.disconnectDisclaimer
@@ -34,8 +33,7 @@ import org.junit.Assert
 @ExperimentalCoroutinesApi
 class Navigator {
     fun resetApp() {
-        Dispatcher.shared.dispatch(DataStoreAction.Lock)
-        DataStore.shared.state.blockingNext()
+        Dispatcher.shared.dispatch(LifecycleAction.UseTestData)
         Dispatcher.shared.dispatch(DataStoreAction.Unlock)
         DataStore.shared.state.blockingNext()
         Dispatcher.shared.dispatch(LifecycleAction.UserReset)
@@ -43,12 +41,7 @@ class Navigator {
         checkAtWelcome()
     }
 
-    fun gotoWelcome() {
-        Dispatcher.shared.dispatch(RouteAction.Welcome)
-    }
-
     fun gotoFxALogin() {
-        gotoWelcome()
         welcome { tapGetStarted() }
         checkAtFxALogin()
     }

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -13,6 +13,7 @@ import android.support.test.espresso.NoActivityResumedException
 import android.support.test.espresso.intent.Intents
 import br.com.concretesolutions.kappuccino.custom.intent.IntentMatcherInteractions.sentIntent
 import br.com.concretesolutions.kappuccino.custom.intent.IntentMatcherInteractions.stubIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.RouteAction
@@ -27,14 +28,18 @@ import mozilla.lockbox.robots.lockScreen
 import mozilla.lockbox.robots.securityDisclaimer
 import mozilla.lockbox.robots.settings
 import mozilla.lockbox.robots.welcome
+import mozilla.lockbox.store.DataStore
 import org.junit.Assert
 
+@ExperimentalCoroutinesApi
 class Navigator {
     fun resetApp() {
+        Dispatcher.shared.dispatch(DataStoreAction.Lock)
+        DataStore.shared.state.blockingNext()
         Dispatcher.shared.dispatch(DataStoreAction.Unlock)
-        Thread.sleep(200L)
+        DataStore.shared.state.blockingNext()
         Dispatcher.shared.dispatch(LifecycleAction.UserReset)
-        Thread.sleep(200L)
+        DataStore.shared.state.blockingNext()
         checkAtWelcome()
     }
 
@@ -62,6 +67,7 @@ class Navigator {
             fxaLogin { tapPlaceholderLogin() }
         } else {
             Dispatcher.shared.dispatch(LifecycleAction.UseTestData)
+            DataStore.shared.state.blockingNext()
         }
         checkAtItemList()
     }

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox
 
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.robots.filteredItemList
 import mozilla.lockbox.view.RootActivity
@@ -21,6 +22,7 @@ import org.junit.runner.RunWith
  *
  * See [testing documentation](http://d.android.com/tools/testing).
  */
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 open class RoutePresenterTest {
     private val navigator = Navigator()

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -159,7 +159,8 @@ open class DataStore(
     }
 
     private fun reset() {
-        if (stateSubject.value == State.Unprepared) {
+        if (stateSubject.value == State.Unprepared ||
+            stateSubject.value == null) {
             return
         }
         clearList()
@@ -185,12 +186,7 @@ open class DataStore(
         if (!credentials.isNew) return
 
         if (backend.isLocked()) {
-            backend.unlock(support.encryptionKey)
-                .asSingle(Dispatchers.Default)
-                .subscribe { _, _ ->
-                    stateSubject.onNext(State.Unlocked)
-                }
-                .addTo(compositeDisposable)
+            unlock()
         } else {
             stateSubject.onNext(State.Unlocked)
         }


### PR DESCRIPTION
Closes #244 (again)

Connected to #240

## Testing and Review Notes

This should resolve the issue surfaced via autolock testing on #240 in which first-time login would not trigger a sync.

## To Do

- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
