### PR TITLE
Improve generation of Device-local Encryption Keys

### DIFF
--- a/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
@@ -32,26 +32,23 @@ class FxASyncDataStoreSupport(
         }
 
         // val encryptionKey = randomUUID().toString()
-        val encryptionKey = generateRandomString(50)
+        val encryptionKey = generateRandomString(32)
         preferences.putString(Constant.Key.encryptionKey, encryptionKey)
 
         encryptionKey
     }
 
-    /*
-     * This serves as a placeholder, and should definitely not be considered secure.
-     * TODO make this cryptographically interesting; add method to KeyStore/DataProtect
-     */
     private fun generateRandomString(keyLength: Int): String {
-        val charPool = "0123456789ABCDEF".toCharArray()
-
-        val bytes = ByteArray(keyLength)
+        val bytes = ByteArray(keyLength * 2)
         val random = SecureRandom()
         random.nextBytes(bytes)
 
         return bytes
             .map {
-                charPool[(it.toInt() and 0xFF % charPool.size)]
+                val full = it.toInt()
+                val hi = (full and 0xf0) ushr 4
+                val lo = full and 0x0f
+                "%h%h".format(hi, lo)
             }
             .joinToString("")
     }

--- a/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
@@ -14,6 +14,24 @@ import mozilla.components.service.sync.logins.AsyncLoginsStorageAdapter
 import mozilla.lockbox.store.ContextStore
 import java.security.SecureRandom
 
+/**
+ * @param keyStrength The strength ofthe generated key in bits
+ */
+internal fun generateEncryptionKey(keyStrength: Int): String {
+    val bytes = ByteArray(keyStrength / 8)
+    val random = SecureRandom()
+    random.nextBytes(bytes)
+
+    return bytes
+        .map {
+            val full = it.toInt()
+            val hi = (full and 0xf0) ushr 4
+            val lo = full and 0x0f
+            "%x%x".format(hi, lo)
+        }
+        .joinToString("")
+}
+
 class FxASyncDataStoreSupport(
     private val preferences: SecurePreferences = SecurePreferences.shared
 ) : DataStoreSupport, ContextStore {
@@ -35,24 +53,6 @@ class FxASyncDataStoreSupport(
         preferences.putString(Constant.Key.encryptionKey, encryptionKey)
 
         encryptionKey
-    }
-
-    /**
-     * @param keyStrength The strength ofthe generated key in bits
-     */
-    private fun generateEncryptionKey(keyStrength: Int): String {
-        val bytes = ByteArray(keyStrength / 8)
-        val random = SecureRandom()
-        random.nextBytes(bytes)
-
-        return bytes
-            .map {
-                val full = it.toInt()
-                val hi = (full and 0xf0) ushr 4
-                val lo = full and 0x0f
-                "%x%x".format(hi, lo)
-            }
-            .joinToString("")
     }
 
     override fun createLoginsStorage(): AsyncLoginsStorage = AsyncLoginsStorageAdapter(DatabaseLoginsStorage(dbFilePath))

--- a/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
@@ -32,14 +32,17 @@ class FxASyncDataStoreSupport(
         }
 
         // val encryptionKey = randomUUID().toString()
-        val encryptionKey = generateRandomString(32)
+        val encryptionKey = generateEncryptionKey(256)
         preferences.putString(Constant.Key.encryptionKey, encryptionKey)
 
         encryptionKey
     }
 
-    private fun generateRandomString(keyLength: Int): String {
-        val bytes = ByteArray(keyLength * 2)
+    /**
+     * @param keyStrength The strength ofthe generated key in bits
+     */
+    private fun generateEncryptionKey(keyStrength: Int): String {
+        val bytes = ByteArray(keyStrength / 8)
         val random = SecureRandom()
         random.nextBytes(bytes)
 

--- a/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FxASyncDataStoreSupport.kt
@@ -31,7 +31,6 @@ class FxASyncDataStoreSupport(
             return@lazy it
         }
 
-        // val encryptionKey = randomUUID().toString()
         val encryptionKey = generateEncryptionKey(256)
         preferences.putString(Constant.Key.encryptionKey, encryptionKey)
 
@@ -51,7 +50,7 @@ class FxASyncDataStoreSupport(
                 val full = it.toInt()
                 val hi = (full and 0xf0) ushr 4
                 val lo = full and 0x0f
-                "%h%h".format(hi, lo)
+                "%x%x".format(hi, lo)
             }
             .joinToString("")
     }

--- a/app/src/test/java/mozilla/lockbox/support/FxASyncDataStoreSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/FxASyncDataStoreSupportTest.kt
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.support
+
+import org.junit.Assert
+import org.junit.Test
+
+class FxASyncDataStoreSupportTest {
+    @Test
+    fun `test encryption key generation`() {
+        val pattern = Regex("[0-9a-f]+", RegexOption.IGNORE_CASE)
+
+        var keyStr = generateEncryptionKey(128)
+        Assert.assertEquals(32, keyStr.length)
+        Assert.assertTrue(pattern.matches(keyStr))
+
+        var oldKeyStr = keyStr
+        keyStr = generateEncryptionKey(256)
+        Assert.assertEquals(64, keyStr.length)
+        Assert.assertTrue(pattern.matches(keyStr))
+        Assert.assertFalse(keyStr == oldKeyStr)
+
+        oldKeyStr = keyStr
+        keyStr = generateEncryptionKey(256)
+        Assert.assertEquals(64, keyStr.length)
+        Assert.assertTrue(pattern.matches(keyStr))
+        Assert.assertFalse(keyStr == oldKeyStr)
+    }
+}


### PR DESCRIPTION
Fixes #228

Improves how the SQLCipher key is generated to provide the entropy we desire (>= 256 bits).

## Testing and Review Notes

This requires a review of the implementation; it's not directly verifiable per se.

* [x] review from one of (@rfk / @vladikoff / @eoger)
* [x] review from one of (@ncalexan  / @thomcc)

## To Do

- ~add “WIP” to the PR title if pushing up but not complete nor ready for review~
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- ~request the "UX" team perform a design review (if/when applicable)~
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- ~check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI~