### PR TITLE
minor update to "no matching entries" list styles

### DIFF
--- a/app/src/main/res/layout/list_cell_no_matching.xml
+++ b/app/src/main/res/layout/list_cell_no_matching.xml
@@ -12,30 +12,31 @@
     android:background="@color/backgroundGrey">
 
     <TextView
-        android:layout_width="158dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:textAlignment="center"
-        android:textSize="17sp"
-        android:fontFamily="sans-serif"
-        android:textStyle="normal"
-        android:textColor="@color/textGrey"
-        android:lineSpacingExtra="8.5sp"
-        android:layout_marginTop="40dp"
-        android:text="@string/no_matching_entries" />
+            android:layout_width="178dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textAlignment="center"
+            android:textSize="17sp"
+            android:fontFamily="sans-serif"
+            android:textStyle="normal"
+            android:textColor="@color/textGrey"
+            android:background="@color/backgroundGrey"
+            android:lineSpacingExtra="8.5sp"
+            android:layout_marginTop="40dp"
+            android:text="@string/no_matching_entries" android:lineHeight="19.5sp"/>
 
     <TextView
-        android:layout_width="280dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:textAlignment="center"
-        android:textSize="13sp"
-        android:fontFamily="sans-serif"
-        android:textStyle="normal"
-        android:textColor="@color/textGrey"
-        android:lineSpacingExtra="6.5sp"
-        android:layout_marginTop="4dp"
-        android:text="@string/save_firefox_disclaimer" />
+            android:layout_width="220dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textAlignment="center"
+            android:textSize="13sp"
+            android:fontFamily="sans-serif"
+            android:textStyle="normal"
+            android:textColor="@color/textGrey"
+            android:background="@color/backgroundGrey"
+            android:layout_marginTop="4dp"
+            android:text="@string/save_firefox_disclaimer" android:lineHeight="19.5dp"/>
 
     <Button
         android:layout_width="wrap_content"


### PR DESCRIPTION
Quick fix to get rid of the white background and wrapping

Source: https://app.zeplin.io/project/5b6895bfe4af825140aa8dbc/screen/5b6915c80d0fa051e278bf18

## Before

![image](https://user-images.githubusercontent.com/49511/50355869-41e8cb80-050d-11e9-91ac-078726660e29.png)


## After

![device-2018-12-21-104126](https://user-images.githubusercontent.com/49511/50355818-25e52a00-050d-11e9-866c-feac85ebfdd0.png)
