### PR TITLE
hide screen in app switcher & disallow screenshots

### DIFF
--- a/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox.view
 
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.view.WindowManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.RoutePresenter
@@ -19,6 +20,7 @@ class RootActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_root)
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
 
         presenter.onViewReady()
     }


### PR DESCRIPTION
Fixes #329 

## Testing and Review Notes

This PR should both disallow screenshots inside the app and hide its contents in the app switcher.

## To Do

- ~~add “WIP” to the PR title if pushing up but not complete nor ready for review~~
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
