### PR TITLE
Remove default project and FxA codecov statuses to reduce noise

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,12 +5,8 @@ coverage:
   precision: 1
   status:
     project:
-      default:
-        threshold: 5
-      fxa: # declare a new status context for FxA
-        paths: "app/src/main/java/mozilla/lockbox/store/AccountStore.kt"
-        target: 0%
-      app: # declare a new status context without
+      default: false  # disable the default status that measures entire project
+      app: # declare a new status context without FxA
         paths: "!app/src/main/java/mozilla/lockbox/store/AccountStore.kt"
     patch:
         default:


### PR DESCRIPTION
This removes the "fxa" and "project" code coverage statuses from reporting back on GitHub.

They were introduced to see our coverage of the overall project vs. our app code vs the uncovered fxa code at #196 but now the number of checks seems excessive and not helpful anymore. We know (roughly) where things are...

@mozilla-lockbox/mobile-engineering does anyone *disagree* with my removal of these two extra coverage statuses?

This means we'll just have:

1. patch: just the code affected in the change
2. project/app: coverage of project code, but not including the AccountStore

## Screenshots or Videos

<img width="714" alt="commits_ _mozilla-lockbox_lockbox-android" src="https://user-images.githubusercontent.com/49511/50651537-ebce4c00-0f40-11e9-8e41-2dbe28f1771a.png">