### PR TITLE
Ensure that the lock screen is maintained when the app is supposed to be locked.

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
+        <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,13 +63,13 @@ configurations {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.android.support:appcompat-v7:${android_support_version}"
-    implementation "com.android.support:cardview-v7:${android_support_version}"
-    implementation "com.android.support:design:${android_support_version}"
-    implementation "com.android.support:recyclerview-v7:${android_support_version}"
-    implementation "com.android.support:support-v4:${android_support_version}"
-    implementation "com.android.support:exifinterface:${android_support_version}"
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.1.0-alpha01'
+    implementation 'androidx.cardview:cardview:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0-alpha02'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0-alpha01'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.exifinterface:exifinterface:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
     implementation "com.jakewharton.rxbinding2:rxbinding:${rxbinding_version}"
     implementation "com.jakewharton.rxbinding2:rxbinding-design-kotlin:${rxbinding_version}"
     implementation "com.jakewharton.rxbinding2:rxbinding-appcompat-v7-kotlin:${rxbinding_version}"
@@ -94,8 +94,8 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.2'
     releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
     testImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
-    implementation "android.arch.lifecycle:extensions:$lifecycle_version"
-    implementation "android.arch.lifecycle:common-java8:$lifecycle_version"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0-alpha01'
+    implementation 'androidx.lifecycle:lifecycle-common-java8:2.1.0-alpha01'
     implementation "android.arch.navigation:navigation-fragment:$navigation_version"
     implementation "android.arch.navigation:navigation-ui-ktx:$navigation_version"
     testImplementation 'junit:junit:4.12'
@@ -105,13 +105,15 @@ dependencies {
     testImplementation "org.powermock:powermock-api-mockito2:2.0.0-beta.5"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"
     androidTestImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"
-    androidTestImplementation "androidx.test:core:1.1.0"
-    androidTestImplementation "androidx.test.ext:junit:1.1.0"
+    androidTestImplementation "androidx.test:core:$androidxTest_version"
+    androidTestImplementation "androidx.test.ext:junit:$androidxTest_version"
+    androidTestImplementation "androidx.test:runner:$androidxTest_version"
+    androidTestImplementation "androidx.test:rules:$androidxTest_version"
+    androidTestUtil "androidx.test:orchestrator:$androidxTest_version"
     androidTestImplementation 'org.mockito:mockito-android:2.22.0'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation("com.android.support.test.espresso:espresso-contrib:3.0.2") {
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.0'
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.1.0") {
         exclude group: 'com.android.support', module: 'appcompat'
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'support-v7'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,9 +116,9 @@ dependencies {
     androidTestImplementation "androidx.test:rules:$androidxTest_version"
     androidTestUtil "androidx.test:orchestrator:$androidxTest_version"
     androidTestImplementation 'org.mockito:mockito-android:2.22.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.0'
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.1.0") {
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.1.1'
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.1.1") {
         exclude group: 'com.android.support', module: 'appcompat'
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'support-v7'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,11 @@ android {
         targetSdkVersion 26
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        // The following argument makes the Android Test Orchestrator run its
+        // "pm clear" command after each test invocation. This command ensures
+        // that the app's state is completely cleared between tests.
+        testInstrumentationRunnerArguments clearPackageData: 'true'
     }
     buildTypes {
         debug {
@@ -49,6 +53,7 @@ android {
             includeAndroidResources = true
             returnDefaultValues = true
         }
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
     packagingOptions {
         exclude 'META-INF/LICENSE.md'

--- a/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
@@ -1,7 +1,8 @@
 package mozilla.lockbox
 
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.Setting
@@ -28,12 +29,12 @@ class TestLockingSupport() : LockingSupport {
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
+@LargeTest
 open class AutoLockTest {
     private val navigator = Navigator()
     private val testLockingSupport = TestLockingSupport(AutoLockStore.shared.lockingSupport)
 
-    @Rule
-    @JvmField
+    @get:Rule
     val activityRule: ActivityTestRule<RootActivity> = ActivityTestRule(RootActivity::class.java)
 
     @Before

--- a/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
@@ -7,7 +7,6 @@ import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.AutoLockStore
-import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.support.LockingSupport
 import mozilla.lockbox.view.RootActivity
 import org.junit.Before

--- a/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
@@ -1,12 +1,15 @@
 package mozilla.lockbox
 
+import android.content.Intent
 import androidx.test.rule.ActivityTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.LifecycleAction
+import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.store.AutoLockStore
 import mozilla.lockbox.support.LockingSupport
 import mozilla.lockbox.view.RootActivity
@@ -50,7 +53,23 @@ open class AutoLockTest {
         testLockingSupport.advance(Setting.AutoLockTime.FiveMinutes.ms + 1000)
 
         Dispatcher.shared.dispatch(LifecycleAction.Foreground)
+        navigator.blockUntil(RouteAction.LockScreen)
+        navigator.checkAtLockScreen()
+    }
 
+    @Test
+    fun lockSurvivesBackButton() {
+        navigator.gotoItemList()
+        itemList {
+            tapLockNow()
+        }
+
+        navigator.checkAtLockScreen()
+
+        navigator.back(false)
+
+        activityRule.launchActivity(Intent(Intent.ACTION_MAIN))
+        navigator.blockUntil(RouteAction.LockScreen)
         navigator.checkAtLockScreen()
     }
 

--- a/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
@@ -69,7 +69,6 @@ open class AutoLockTest {
 
     @Test
     fun firstTimeLoginFlowInterruptTest() {
-        navigator.resetApp(activityRule)
         navigator.gotoFxALogin()
 
         Dispatcher.shared.dispatch(LifecycleAction.Background)
@@ -85,10 +84,8 @@ open class AutoLockTest {
     fun disconnectAndReLoginFlowInterruptTest() {
         navigator.gotoItemList()
 
-        Dispatcher.shared.dispatch(LifecycleAction.UserReset)
-        DataStore.shared.state.blockingNext()
+        navigator.disconnectAccount()
 
-        navigator.checkAtWelcome()
         navigator.gotoFxALogin()
 
         Dispatcher.shared.dispatch(LifecycleAction.Background)

--- a/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/AutoLockTest.kt
@@ -40,7 +40,6 @@ open class AutoLockTest {
     @Before
     fun setUp() {
         AutoLockStore.shared.lockingSupport = testLockingSupport
-        navigator.resetApp(activityRule)
     }
 
     @Test

--- a/app/src/androidTest/java/mozilla/lockbox/FingerprintDialogTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/FingerprintDialogTest.kt
@@ -7,7 +7,7 @@
 package mozilla.lockbox
 
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.lockbox.robots.fingerprintDialog
 import mozilla.lockbox.robots.uiComponents
 import mozilla.lockbox.view.UITestActivity

--- a/app/src/androidTest/java/mozilla/lockbox/FingerprintDialogTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/FingerprintDialogTest.kt
@@ -6,8 +6,8 @@
 
 package mozilla.lockbox
 
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
 import mozilla.lockbox.robots.fingerprintDialog
 import mozilla.lockbox.robots.uiComponents
 import mozilla.lockbox.view.UITestActivity

--- a/app/src/androidTest/java/mozilla/lockbox/ItemListTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/ItemListTest.kt
@@ -1,7 +1,7 @@
 package mozilla.lockbox
 
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.view.RootActivity
 import org.junit.Rule

--- a/app/src/androidTest/java/mozilla/lockbox/ItemListTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/ItemListTest.kt
@@ -1,7 +1,7 @@
 package mozilla.lockbox
 
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
 import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.view.RootActivity
 import org.junit.Rule

--- a/app/src/androidTest/java/mozilla/lockbox/LockboxAutofillServiceTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/LockboxAutofillServiceTest.kt
@@ -1,7 +1,7 @@
 package mozilla.lockbox
 
-import android.support.test.rule.ServiceTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.rule.ServiceTestRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -19,6 +19,7 @@ import io.reactivex.subjects.ReplaySubject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
+import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.robots.accountSettingScreen
 import mozilla.lockbox.robots.disconnectDisclaimer
@@ -31,8 +32,10 @@ import mozilla.lockbox.robots.securityDisclaimer
 import mozilla.lockbox.robots.settings
 import mozilla.lockbox.robots.welcome
 import mozilla.lockbox.store.DataStore
+import mozilla.lockbox.store.RouteStore
 import mozilla.lockbox.view.RootActivity
 import org.junit.Assert
+import java.lang.Thread.sleep
 
 @ExperimentalCoroutinesApi
 class Navigator {
@@ -62,6 +65,10 @@ class Navigator {
         Dispatcher.shared.dispatch(LifecycleAction.UserReset)
         blockUntil(DataStore.State.Unprepared)
         checkAtWelcome()
+    }
+
+    fun blockUntil(vararg states: RouteAction) {
+        blockUntil(RouteStore.shared.routes, *states)
     }
 
     fun blockUntil(vararg states: DataStore.State) {
@@ -95,7 +102,8 @@ class Navigator {
             fxaLogin { tapPlaceholderLogin() }
         } else {
             Dispatcher.shared.dispatch(LifecycleAction.UseTestData)
-            blockUntil(DataStore.State.Unlocked)
+            log.info("blocking for the routes")
+            blockUntil(RouteStore.shared.routes, RouteAction.ItemList)
         }
         checkAtItemList()
     }

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -7,11 +7,11 @@
 package mozilla.lockbox
 
 import android.provider.Settings
-import android.support.test.espresso.Espresso.closeSoftKeyboard
-import android.support.test.espresso.Espresso.pressBack
-import android.support.test.espresso.NoActivityResumedException
-import android.support.test.espresso.intent.Intents
-import android.support.test.rule.ActivityTestRule
+import androidx.test.espresso.Espresso.closeSoftKeyboard
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.NoActivityResumedException
+import androidx.test.espresso.intent.Intents
+import androidx.test.rule.ActivityTestRule
 import br.com.concretesolutions.kappuccino.custom.intent.IntentMatcherInteractions.sentIntent
 import br.com.concretesolutions.kappuccino.custom.intent.IntentMatcherInteractions.stubIntent
 import io.reactivex.Observable

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -53,11 +53,12 @@ class Navigator {
             }
 
             is DataStore.State.Unprepared -> {
+                // We're done already.
                 return
             }
 
             else -> {
-                // NOP
+                // Nothing more needs to be done to prepare for the user reset.
             }
         }
 

--- a/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/Navigator.kt
@@ -35,7 +35,6 @@ import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.store.RouteStore
 import mozilla.lockbox.view.RootActivity
 import org.junit.Assert
-import java.lang.Thread.sleep
 
 @ExperimentalCoroutinesApi
 class Navigator {

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -6,8 +6,8 @@
 
 package mozilla.lockbox
 
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.robots.filteredItemList

--- a/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/RoutePresenterTest.kt
@@ -7,12 +7,11 @@
 package mozilla.lockbox
 
 import androidx.test.rule.ActivityTestRule
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.robots.disconnectDisclaimer
 import mozilla.lockbox.robots.filteredItemList
 import mozilla.lockbox.view.RootActivity
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,11 +28,6 @@ open class RoutePresenterTest {
 
     @Rule @JvmField
     val activityRule: ActivityTestRule<RootActivity> = ActivityTestRule(RootActivity::class.java)
-
-    @Before
-    fun setUp() {
-        navigator.resetApp(activityRule)
-    }
 
     @Test
     fun testFxALogin() {

--- a/app/src/androidTest/java/mozilla/lockbox/robots/BaseTestRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/BaseTestRobot.kt
@@ -6,16 +6,16 @@
 
 package mozilla.lockbox.robots
 
-import android.support.test.espresso.Espresso
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.NoActivityResumedException
-import android.support.test.espresso.ViewInteraction
-import android.support.test.espresso.action.ViewActions.closeSoftKeyboard
-import android.support.test.espresso.action.ViewActions.replaceText
-import android.support.test.espresso.action.ViewActions.swipeDown
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.withId
-import android.support.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.NoActivityResumedException
+import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.replaceText
+import androidx.test.espresso.action.ViewActions.swipeDown
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import br.com.concretesolutions.kappuccino.custom.recyclerView.RecyclerViewInteractions.recyclerView
 import junit.framework.Assert
 

--- a/app/src/androidTest/java/mozilla/lockbox/robots/ItemListRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/ItemListRobot.kt
@@ -6,11 +6,11 @@
 
 package mozilla.lockbox.robots
 
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.ViewInteraction
-import android.support.test.espresso.contrib.DrawerActions
-import android.support.test.espresso.contrib.NavigationViewActions.navigateTo
-import android.support.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.contrib.DrawerActions
+import androidx.test.espresso.contrib.NavigationViewActions.navigateTo
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import br.com.concretesolutions.kappuccino.actions.ClickActions.click
 import br.com.concretesolutions.kappuccino.assertions.VisibilityAssertions.displayed
 import kotlinx.android.synthetic.main.fragment_item_list.view.*

--- a/app/src/androidTest/java/mozilla/lockbox/robots/ItemListRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/ItemListRobot.kt
@@ -57,7 +57,10 @@ class ItemListRobot : BaseTestRobot {
 
     fun tapSettings() = menuOption(R.id.setting_menu_item)
 
-    fun tapLockNow() = click { id(R.id.lockNow) }
+    fun tapLockNow() {
+        openMenu()
+        click { id(R.id.lockNow) }
+    }
 
     fun tapAccountSetting() = menuOption(R.id.account_setting_menu_item)
 

--- a/app/src/debug/java/mozilla/lockbox/view/UITestActivity.kt
+++ b/app/src/debug/java/mozilla/lockbox/view/UITestActivity.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.view
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
 import mozilla.lockbox.R

--- a/app/src/debug/res/layout/activity_test.xml
+++ b/app/src/debug/res/layout/activity_test.xml
@@ -4,13 +4,13 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/uiComponents"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".view.UITestActivity">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                   xmlns:tools="http://schemas.android.com/tools"
+                                                   android:id="@+id/uiComponents"
+                                                   android:layout_width="match_parent"
+                                                   android:layout_height="match_parent"
+                                                   tools:context=".view.UITestActivity">
 
     <Button
         android:id="@+id/button_launch_fingerprint"
@@ -39,4 +39,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/debug/res/layout/activity_test.xml
+++ b/app/src/debug/res/layout/activity_test.xml
@@ -5,12 +5,12 @@
   -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   xmlns:tools="http://schemas.android.com/tools"
-                                                   android:id="@+id/uiComponents"
-                                                   android:layout_width="match_parent"
-                                                   android:layout_height="match_parent"
-                                                   tools:context=".view.UITestActivity">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/uiComponents"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.UITestActivity">
 
     <Button
         android:id="@+id/button_launch_fingerprint"

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -7,7 +7,7 @@
 package mozilla.lockbox
 
 import android.app.Application
-import android.arch.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import android.os.Build
 import com.squareup.leakcanary.LeakCanary
 import io.sentry.Sentry

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.action
 
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import mozilla.lockbox.R
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.support.Constant

--- a/app/src/main/java/mozilla/lockbox/action/SettingAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/SettingAction.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.action
 
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import mozilla.lockbox.R
 import mozilla.lockbox.flux.Action
 

--- a/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -22,9 +22,9 @@ import mozilla.lockbox.model.ItemViewModel
 import mozilla.lockbox.view.ItemViewHolder
 
 open class ItemListCell(override val containerView: View)
-    : RecyclerView.ViewHolder(containerView), LayoutContainer
+    : androidx.recyclerview.widget.RecyclerView.ViewHolder(containerView), LayoutContainer
 
-class ItemListAdapter : RecyclerView.Adapter<ItemListCell>() {
+class ItemListAdapter : androidx.recyclerview.widget.RecyclerView.Adapter<ItemListCell>() {
 
     private var itemList: List<ItemViewModel>? = null
     private val _clicks = PublishSubject.create<ItemViewModel>()

--- a/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
@@ -22,9 +22,9 @@ import mozilla.lockbox.model.ItemViewModel
 import mozilla.lockbox.view.ItemViewHolder
 
 open class ItemListCell(override val containerView: View)
-    : androidx.recyclerview.widget.RecyclerView.ViewHolder(containerView), LayoutContainer
+    : RecyclerView.ViewHolder(containerView), LayoutContainer
 
-class ItemListAdapter : androidx.recyclerview.widget.RecyclerView.Adapter<ItemListCell>() {
+class ItemListAdapter : RecyclerView.Adapter<ItemListCell>() {
 
     private var itemList: List<ItemViewModel>? = null
     private val _clicks = PublishSubject.create<ItemViewModel>()

--- a/app/src/main/java/mozilla/lockbox/adapter/SectionedAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SectionedAdapter.kt
@@ -9,8 +9,8 @@
 
 package mozilla.lockbox.adapter
 
-import android.support.annotation.StringRes
-import android.support.v7.widget.RecyclerView
+import androidx.annotation.StringRes
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.TextView
@@ -22,8 +22,8 @@ import mozilla.lockbox.R
 class SectionedAdapter(
     private val sectionLayoutId: Int,
     private val sectionTitleId: Int,
-    private val baseAdapter: RecyclerView.Adapter<RecyclerView.ViewHolder>
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private val baseAdapter: androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>
+) : androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>() {
 
     private var valid = true
     private val sections = SparseArray<Section>()
@@ -32,11 +32,11 @@ class SectionedAdapter(
         const val SECTION_TYPE = 0
     }
 
-    class SectionViewHolder(view: View, titleResourceId: Int) : RecyclerView.ViewHolder(view) {
+    class SectionViewHolder(view: View, titleResourceId: Int) : androidx.recyclerview.widget.RecyclerView.ViewHolder(view) {
         var title: TextView = view.findViewById(titleResourceId)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, typeView: Int): RecyclerView.ViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, typeView: Int): androidx.recyclerview.widget.RecyclerView.ViewHolder {
         return if (typeView == SECTION_TYPE) {
             val view = LayoutInflater.from(parent.context).inflate(sectionLayoutId, parent, false)
             SectionViewHolder(view, sectionTitleId)
@@ -45,7 +45,7 @@ class SectionedAdapter(
         }
     }
 
-    override fun onBindViewHolder(sectionViewHolder: RecyclerView.ViewHolder, position: Int) {
+    override fun onBindViewHolder(sectionViewHolder: androidx.recyclerview.widget.RecyclerView.ViewHolder, position: Int) {
         if (isSectionHeaderPosition(position)) {
             val title = sectionViewHolder.itemView.context.getString(sections.get(position).title)
             (sectionViewHolder as SectionViewHolder).title.text = title
@@ -107,7 +107,7 @@ class SectionedAdapter(
 
     private fun sectionedPositionToPosition(sectionedPosition: Int): Int {
         if (isSectionHeaderPosition(sectionedPosition)) {
-            return RecyclerView.NO_POSITION
+            return androidx.recyclerview.widget.RecyclerView.NO_POSITION
         }
 
         var offset = 0

--- a/app/src/main/java/mozilla/lockbox/adapter/SectionedAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SectionedAdapter.kt
@@ -11,6 +11,8 @@ package mozilla.lockbox.adapter
 
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.TextView
@@ -22,8 +24,8 @@ import mozilla.lockbox.R
 class SectionedAdapter(
     private val sectionLayoutId: Int,
     private val sectionTitleId: Int,
-    private val baseAdapter: androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>
-) : androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>() {
+    private val baseAdapter: Adapter<ViewHolder>
+) : Adapter<ViewHolder>() {
 
     private var valid = true
     private val sections = SparseArray<Section>()
@@ -32,11 +34,11 @@ class SectionedAdapter(
         const val SECTION_TYPE = 0
     }
 
-    class SectionViewHolder(view: View, titleResourceId: Int) : androidx.recyclerview.widget.RecyclerView.ViewHolder(view) {
+    class SectionViewHolder(view: View, titleResourceId: Int) : ViewHolder(view) {
         var title: TextView = view.findViewById(titleResourceId)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, typeView: Int): androidx.recyclerview.widget.RecyclerView.ViewHolder {
+    override fun onCreateViewHolder(parent: ViewGroup, typeView: Int): ViewHolder {
         return if (typeView == SECTION_TYPE) {
             val view = LayoutInflater.from(parent.context).inflate(sectionLayoutId, parent, false)
             SectionViewHolder(view, sectionTitleId)
@@ -45,7 +47,7 @@ class SectionedAdapter(
         }
     }
 
-    override fun onBindViewHolder(sectionViewHolder: androidx.recyclerview.widget.RecyclerView.ViewHolder, position: Int) {
+    override fun onBindViewHolder(sectionViewHolder: ViewHolder, position: Int) {
         if (isSectionHeaderPosition(position)) {
             val title = sectionViewHolder.itemView.context.getString(sections.get(position).title)
             (sectionViewHolder as SectionViewHolder).title.text = title
@@ -107,7 +109,7 @@ class SectionedAdapter(
 
     private fun sectionedPositionToPosition(sectionedPosition: Int): Int {
         if (isSectionHeaderPosition(sectionedPosition)) {
-            return androidx.recyclerview.widget.RecyclerView.NO_POSITION
+            return RecyclerView.NO_POSITION
         }
 
         var offset = 0

--- a/app/src/main/java/mozilla/lockbox/adapter/SettingCellConfiguration.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SettingCellConfiguration.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.adapter
 
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 

--- a/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
@@ -18,7 +18,7 @@ import mozilla.lockbox.view.SettingViewHolder
 import mozilla.lockbox.view.TextSettingViewHolder
 import mozilla.lockbox.view.ToggleSettingViewHolder
 
-class SettingListAdapter : androidx.recyclerview.widget.RecyclerView.Adapter<SettingViewHolder>() {
+class SettingListAdapter : RecyclerView.Adapter<SettingViewHolder>() {
     private var settingListConfig: List<SettingCellConfiguration> = emptyList()
     private val compositeDisposable = CompositeDisposable()
 
@@ -107,7 +107,7 @@ class SettingListAdapter : androidx.recyclerview.widget.RecyclerView.Adapter<Set
         notifyDataSetChanged()
     }
 
-    override fun onDetachedFromRecyclerView(recyclerView: androidx.recyclerview.widget.RecyclerView) {
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
         compositeDisposable.clear()
     }
 }

--- a/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.jakewharton.rxbinding2.view.clicks
@@ -18,7 +18,7 @@ import mozilla.lockbox.view.SettingViewHolder
 import mozilla.lockbox.view.TextSettingViewHolder
 import mozilla.lockbox.view.ToggleSettingViewHolder
 
-class SettingListAdapter : RecyclerView.Adapter<SettingViewHolder>() {
+class SettingListAdapter : androidx.recyclerview.widget.RecyclerView.Adapter<SettingViewHolder>() {
     private var settingListConfig: List<SettingCellConfiguration> = emptyList()
     private val compositeDisposable = CompositeDisposable()
 
@@ -107,7 +107,7 @@ class SettingListAdapter : RecyclerView.Adapter<SettingViewHolder>() {
         notifyDataSetChanged()
     }
 
-    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+    override fun onDetachedFromRecyclerView(recyclerView: androidx.recyclerview.widget.RecyclerView) {
         compositeDisposable.clear()
     }
 }

--- a/app/src/main/java/mozilla/lockbox/extensions/Observable+.kt
+++ b/app/src/main/java/mozilla/lockbox/extensions/Observable+.kt
@@ -16,19 +16,19 @@ fun <T : Any, U : T> Observable<T>.filterByType(clazz: Class<out U>): Observable
     return this.filter { t -> clazz.isInstance(t) }.map { t -> clazz.cast(t) }
 }
 
-fun <T : Any> Observable<T>.debug(): Observable<T> {
+fun <T : Any> Observable<T>.debug(message: String = "observer"): Observable<T> {
     return this
         .doOnSubscribe {
-            LogProvider.log.info("subscribed")
+            LogProvider.log.info("$message: subscribed")
         }
         .doOnNext {
-            LogProvider.log.info("event: $it")
+            LogProvider.log.info("$message: event: $it")
         }
         .doOnError {
-            LogProvider.log.info("error: ${it.localizedMessage}")
+            LogProvider.log.info("$message: error: ${it.localizedMessage}")
         }
         .doOnDispose {
-            LogProvider.log.info("disposed")
+            LogProvider.log.info("$message: disposed")
         }
 }
 

--- a/app/src/main/java/mozilla/lockbox/extensions/view/AlertDialog+.kt
+++ b/app/src/main/java/mozilla/lockbox/extensions/view/AlertDialog+.kt
@@ -8,9 +8,9 @@ package mozilla.lockbox.extensions.view
 
 import android.content.Context
 import android.content.DialogInterface
-import android.support.annotation.ColorRes
-import android.support.annotation.StringRes
-import android.support.v7.app.AlertDialog
+import androidx.annotation.ColorRes
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
 import io.reactivex.Observable
 import io.reactivex.ObservableEmitter
 import mozilla.lockbox.R

--- a/app/src/main/java/mozilla/lockbox/flux/Presenter.kt
+++ b/app/src/main/java/mozilla/lockbox/flux/Presenter.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.flux
 
-import android.support.annotation.CallSuper
+import androidx.annotation.CallSuper
 import io.reactivex.disposables.CompositeDisposable
 
 abstract class Presenter {

--- a/app/src/main/java/mozilla/lockbox/presenter/ApplicationPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ApplicationPresenter.kt
@@ -6,8 +6,8 @@
 
 package mozilla.lockbox.presenter
 
-import android.arch.lifecycle.DefaultLifecycleObserver
-import android.arch.lifecycle.LifecycleOwner
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.flux.Dispatcher
 

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.presenter
 
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
 import io.reactivex.rxkotlin.addTo

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.presenter
 
-import android.support.annotation.IdRes
+import androidx.annotation.IdRes
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.rxkotlin.Observables

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -9,7 +9,6 @@ package mozilla.lockbox.presenter
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.provider.ContactsContract
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
@@ -35,7 +34,6 @@ import mozilla.lockbox.model.SyncCredentials
 import mozilla.lockbox.store.AccountStore
 import mozilla.lockbox.store.AutoLockStore
 import mozilla.lockbox.store.DataStore
-import mozilla.lockbox.store.DataStore.State
 import mozilla.lockbox.store.RouteStore
 import mozilla.lockbox.store.SettingStore
 import mozilla.lockbox.support.Optional
@@ -76,7 +74,6 @@ class RoutePresenter(
             .subscribe(this::route)
             .addTo(compositeDisposable)
     }
-
 
     private fun accountToDataStoreActions(optCredentials: Optional<SyncCredentials>): DataStoreAction {
         // we will get a null credentials object (and subsequently reset the datastore) on

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -59,6 +59,7 @@ class RoutePresenter(
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
 
         val autoLockActions = autoLockStore.activateAutoLockMEGAZORD
+            .filter { it }
             .map { DataStoreAction.Lock }
 
         // Moves credentials from the AccountStore, into the DataStore.

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -10,8 +10,8 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.ContactsContract
-import android.support.annotation.IdRes
-import android.support.v7.app.AppCompatActivity
+import androidx.annotation.IdRes
+import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import io.reactivex.Observable

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -57,7 +57,7 @@ class RoutePresenter(
     override fun onViewReady() {
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
 
-        val autoLockActions = autoLockStore.activateAutoLockMEGAZORD
+        val autoLockActions = autoLockStore.autoLockActivated
             .filter { it }
             .map { DataStoreAction.Lock }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -69,7 +69,7 @@ class RoutePresenter(
             .addTo(compositeDisposable)
 
         routeStore.routes
-            .debug("mapping to actual behavior from routeStore.routes")
+            .debug("routeStore.routes to routepresenter")
             .observeOn(mainThread())
             .subscribe(this::route)
             .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -22,7 +22,6 @@ import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.action.SettingAction
-import mozilla.lockbox.extensions.debug
 import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.extensions.view.AlertDialogHelper
 import mozilla.lockbox.extensions.view.AlertState
@@ -70,7 +69,6 @@ class RoutePresenter(
             .addTo(compositeDisposable)
 
         routeStore.routes
-            .debug("routeStore.routes to routepresenter")
             .observeOn(mainThread())
             .subscribe(this::route)
             .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
@@ -41,7 +41,10 @@ class AutoLockStore(
 
     var lockingSupport: LockingSupport = SystemLockingSupport()
 
-    val activateAutoLockMEGAZORD: Observable<Boolean> = PublishSubject.create()
+    // This fires `true` when the autolock the datastore should be locked.
+    // It is _not_ `Unit` to enable testing.
+    // It's absence, or `false` should mean that autolock is not yet been fired.
+    val autoLockActivated: Observable<Boolean> = PublishSubject.create()
 
     init {
         // update the lock timer when backgrounding and the datastore is not locked
@@ -76,7 +79,7 @@ class AutoLockStore(
             .filter { it == LifecycleAction.Foreground }
             // push lockrequired if required
             .map { lockCurrentlyRequired() }
-            .subscribe(activateAutoLockMEGAZORD as Subject)
+            .subscribe(autoLockActivated as Subject)
     }
 
     override fun injectContext(context: Context) {

--- a/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
@@ -42,7 +42,7 @@ class AutoLockStore(
 
     var lockingSupport: LockingSupport = SystemLockingSupport()
 
-    val activateAutoLockMEGAZORD: Observable<Unit> = PublishSubject.create()
+    val activateAutoLockMEGAZORD: Observable<Boolean> = PublishSubject.create()
 
     init {
         // update the lock timer when backgrounding and the datastore is not locked
@@ -79,9 +79,6 @@ class AutoLockStore(
             .filter { it == LifecycleAction.Foreground }
             // push lockrequired if required
             .map { lockCurrentlyRequired() }
-            .debug("lockingCurrentlyRequired")
-            .filter { it }
-            .map { Unit }
             .subscribe(activateAutoLockMEGAZORD as Subject)
     }
 

--- a/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
@@ -70,11 +70,12 @@ class AutoLockStore(
             .switchMap {
                 if (it is DataStoreAction.UpdateCredentials) {
                 lifecycleStore.lifecycleEvents
-            } else if (it == DataStoreAction.Reset) {
-                Observable.empty<LifecycleAction>()
-            } else {
+                } else if (it == DataStoreAction.Reset) {
                     Observable.empty<LifecycleAction>()
-                } }
+                } else {
+                    Observable.empty<LifecycleAction>()
+                }
+            }
             .filter { it == LifecycleAction.Foreground }
             // push lockrequired if required
             .map { lockCurrentlyRequired() }

--- a/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.Setting
-import mozilla.lockbox.extensions.debug
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.support.Constant

--- a/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
@@ -12,12 +12,14 @@ import android.preference.PreferenceManager
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
-import io.reactivex.subjects.ReplaySubject
+import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.Setting
+import mozilla.lockbox.extensions.debug
+import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.support.Constant
 import mozilla.lockbox.support.LockingSupport
@@ -40,14 +42,10 @@ class AutoLockStore(
 
     var lockingSupport: LockingSupport = SystemLockingSupport()
 
-    val lockRequired: Observable<Boolean> = ReplaySubject.createWithSize(1)
+    val activateAutoLockMEGAZORD: Observable<Unit> = PublishSubject.create()
 
     init {
-        lifecycleStore.lifecycleEvents
-            .filter { it == LifecycleAction.Foreground }
-            .map { lockCurrentlyRequired() }
-            .subscribe(lockRequired as Subject)
-
+        // update the lock timer when backgrounding and the datastore is not locked
         lifecycleStore.lifecycleEvents
             .filter { it == LifecycleAction.Background }
             .switchMap { dataStore.state.take(1) }
@@ -56,19 +54,38 @@ class AutoLockStore(
             .subscribe(this::updateNextLockTime)
             .addTo(compositeDisposable)
 
+        // backdate the lock timer when receiving manual lock actions
         dispatcher.register
-            .filter { it == DataStoreAction.Lock }
-            .switchMap { lockRequired.take(1) }
-            .filter { !it }
+            // make sure that we are not driving the DataStoreAction.Lock
+            .filter { it == DataStoreAction.Lock && !lockCurrentlyRequired() }
             .subscribe {
                 this.backdateNextLockTime()
             }
             .addTo(compositeDisposable)
+
+        dispatcher.register
+            // getting a credential object means we've logged in
+            .filterByType(DataStoreAction::class.java)
+            // begin listening for foreground events after login
+            .switchMap {
+                if (it is DataStoreAction.UpdateCredentials) {
+                lifecycleStore.lifecycleEvents
+            } else if (it == DataStoreAction.Reset) {
+                Observable.empty<LifecycleAction>()
+            } else {
+                    Observable.empty<LifecycleAction>()
+                }}
+            .filter { it == LifecycleAction.Foreground }
+            // push lockrequired if required
+            .map { lockCurrentlyRequired() }
+            .debug("lockingCurrentlyRequired")
+            .filter { it }
+            .map { Unit }
+            .subscribe(activateAutoLockMEGAZORD as Subject)
     }
 
     override fun injectContext(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        (lockRequired as Subject).onNext(lockCurrentlyRequired())
     }
 
     private fun backdateNextLockTime() {

--- a/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
@@ -68,12 +68,10 @@ class AutoLockStore(
             .filterByType(DataStoreAction::class.java)
             // begin listening for foreground events after login
             .switchMap {
-                if (it is DataStoreAction.UpdateCredentials) {
-                lifecycleStore.lifecycleEvents
-                } else if (it == DataStoreAction.Reset) {
-                    Observable.empty<LifecycleAction>()
-                } else {
-                    Observable.empty<LifecycleAction>()
+                when (it) {
+                    is DataStoreAction.UpdateCredentials -> lifecycleStore.lifecycleEvents
+                    is DataStoreAction.Unlock -> lifecycleStore.lifecycleEvents
+                    else -> Observable.empty<LifecycleAction>()
                 }
             }
             .filter { it == LifecycleAction.Foreground }

--- a/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AutoLockStore.kt
@@ -74,7 +74,7 @@ class AutoLockStore(
                 Observable.empty<LifecycleAction>()
             } else {
                     Observable.empty<LifecycleAction>()
-                }}
+                } }
             .filter { it == LifecycleAction.Foreground }
             // push lockrequired if required
             .map { lockCurrentlyRequired() }

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -6,18 +6,47 @@
 
 package mozilla.lockbox.store
 import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.ReplaySubject
+import io.reactivex.subjects.Subject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.extensions.debug
 import mozilla.lockbox.extensions.filterByType
+import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.support.Optional
+import mozilla.lockbox.support.asOptional
 
+@ExperimentalCoroutinesApi
 class RouteStore(
-    dispatcher: Dispatcher = Dispatcher.shared
+    dispatcher: Dispatcher = Dispatcher.shared,
+    dataStore: DataStore = DataStore.shared
 ) {
     companion object {
         val shared = RouteStore()
     }
 
-    val routes: Observable<RouteAction> =
-            dispatcher.register
-                .filterByType(RouteAction::class.java)
+    val routes: Observable<RouteAction> = ReplaySubject.createWithSize(1)
+
+    init {
+        dispatcher.register
+            .filterByType(RouteAction::class.java)
+            .subscribe(routes as Subject)
+
+        dataStore.state
+            .map(this::dataStoreToRouteActions)
+            .filterNotNull()
+            .debug("new datastore routeaction")
+            .subscribe(routes)
+    }
+
+    private fun dataStoreToRouteActions(storageState: DataStore.State): Optional<RouteAction> {
+        return when (storageState) {
+            is DataStore.State.Unlocked -> RouteAction.ItemList
+            is DataStore.State.Locked -> RouteAction.LockScreen
+            is DataStore.State.Unprepared -> RouteAction.Welcome
+            else -> null
+        }.asOptional()
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -6,7 +6,6 @@
 
 package mozilla.lockbox.store
 import io.reactivex.Observable
-import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.ReplaySubject
 import io.reactivex.subjects.Subject
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -36,7 +36,7 @@ class RouteStore(
         dataStore.state
             .map(this::dataStoreToRouteActions)
             .filterNotNull()
-            .debug("new datastore routeaction")
+            .debug("datastorestate to routes")
             .subscribe(routes)
     }
 

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -10,7 +10,6 @@ import io.reactivex.subjects.ReplaySubject
 import io.reactivex.subjects.Subject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.RouteAction
-import mozilla.lockbox.extensions.debug
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.flux.Dispatcher
@@ -36,7 +35,6 @@ class RouteStore(
         dataStore.state
             .map(this::dataStoreToRouteActions)
             .filterNotNull()
-            .debug("datastorestate to routes")
             .subscribe(routes)
     }
 

--- a/app/src/main/java/mozilla/lockbox/view/AppWebPageFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/AppWebPageFragment.kt
@@ -9,7 +9,7 @@ package mozilla.lockbox.view
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/mozilla/lockbox/view/BackableFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/BackableFragment.kt
@@ -9,7 +9,7 @@ import mozilla.lockbox.R
 import mozilla.lockbox.presenter.BackablePresenter
 import mozilla.lockbox.presenter.BackableView
 
-open class BackableFragment : CommonFragment(), BackableView {
+open class BackableFragment : Fragment(), BackableView {
     private lateinit var backablePresenter: BackablePresenter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/mozilla/lockbox/view/CommonFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/CommonFragment.kt
@@ -7,15 +7,15 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v4.view.ViewCompat
+import androidx.fragment.app.Fragment
+import androidx.core.view.ViewCompat
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import mozilla.lockbox.R
 import mozilla.lockbox.flux.Presenter
 
-open class CommonFragment : Fragment() {
+open class CommonFragment : androidx.fragment.app.Fragment() {
     lateinit var presenter: Presenter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/mozilla/lockbox/view/DialogFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/DialogFragment.kt
@@ -8,11 +8,11 @@ package mozilla.lockbox.view
 
 import android.os.Bundle
 import androidx.annotation.StringRes
-import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.DialogFragment as AndroidDialogFragment
 import android.view.View
 import mozilla.lockbox.flux.Presenter
 
-open class DialogFragment : androidx.fragment.app.DialogFragment() {
+open class DialogFragment : AndroidDialogFragment() {
     lateinit var presenter: Presenter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/mozilla/lockbox/view/DialogFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/DialogFragment.kt
@@ -7,12 +7,12 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import android.support.annotation.StringRes
-import android.support.v4.app.DialogFragment
+import androidx.annotation.StringRes
+import androidx.fragment.app.DialogFragment
 import android.view.View
 import mozilla.lockbox.flux.Presenter
 
-open class DialogFragment : DialogFragment() {
+open class DialogFragment : androidx.fragment.app.DialogFragment() {
     lateinit var presenter: Presenter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
@@ -8,8 +8,8 @@ package mozilla.lockbox.view
 
 import android.content.Context
 import android.os.Bundle
-import android.support.v7.widget.DividerItemDecoration
-import android.support.v7.widget.LinearLayoutManager
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -38,10 +38,10 @@ class FilterFragment : BackableFragment(), FilterView {
         presenter = FilterPresenter(this)
         val view = inflater.inflate(R.layout.fragment_filter, container, false)
 
-        val layoutManager = LinearLayoutManager(context)
+        val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
         view.entriesView.layoutManager = layoutManager
         view.entriesView.adapter = adapter
-        val decoration = DividerItemDecoration(context, layoutManager.orientation)
+        val decoration = androidx.recyclerview.widget.DividerItemDecoration(context, layoutManager.orientation)
         val decorationDrawable = context?.getDrawable(R.drawable.inset_divider)
         decorationDrawable?.let { decoration.setDrawable(it) }
         view.entriesView.addItemDecoration(decoration)

--- a/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
@@ -38,10 +38,10 @@ class FilterFragment : BackableFragment(), FilterView {
         presenter = FilterPresenter(this)
         val view = inflater.inflate(R.layout.fragment_filter, container, false)
 
-        val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
+        val layoutManager = LinearLayoutManager(context)
         view.entriesView.layoutManager = layoutManager
         view.entriesView.adapter = adapter
-        val decoration = androidx.recyclerview.widget.DividerItemDecoration(context, layoutManager.orientation)
+        val decoration = DividerItemDecoration(context, layoutManager.orientation)
         val decorationDrawable = context?.getDrawable(R.drawable.inset_divider)
         decorationDrawable?.let { decoration.setDrawable(it) }
         view.entriesView.addItemDecoration(decoration)

--- a/app/src/main/java/mozilla/lockbox/view/FingerprintAuthDialogFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FingerprintAuthDialogFragment.kt
@@ -7,7 +7,7 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -33,7 +33,7 @@ class FingerprintAuthDialogFragment : DialogFragment(), FingerprintDialogView {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setStyle(android.support.v4.app.DialogFragment.STYLE_NORMAL, R.style.NoTitleDialog)
+        setStyle(androidx.fragment.app.DialogFragment.STYLE_NORMAL, R.style.NoTitleDialog)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/mozilla/lockbox/view/Fragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/Fragment.kt
@@ -7,7 +7,7 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
+import androidx.fragment.app.Fragment as AndroidFragment
 import androidx.core.view.ViewCompat
 import android.view.View
 import android.view.animation.Animation
@@ -15,7 +15,7 @@ import android.view.animation.AnimationUtils
 import mozilla.lockbox.R
 import mozilla.lockbox.flux.Presenter
 
-open class CommonFragment : androidx.fragment.app.Fragment() {
+open class Fragment : AndroidFragment() {
     lateinit var presenter: Presenter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -7,7 +7,7 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import android.text.method.PasswordTransformationMethod
 import android.view.Gravity
 import android.view.LayoutInflater

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -7,13 +7,13 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import android.support.design.widget.NavigationView
-import android.support.v4.view.GravityCompat
-import android.support.v4.widget.DrawerLayout
-import android.support.v7.widget.DividerItemDecoration
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
-import android.support.v7.widget.Toolbar
+import com.google.android.material.navigation.NavigationView
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.appcompat.widget.Toolbar
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -104,14 +104,14 @@ class ItemListFragment : CommonFragment(), ItemListView {
         }
     }
 
-    private fun setupNavigationView(navController: NavController, navView: NavigationView) {
+    private fun setupNavigationView(navController: NavController, navView: com.google.android.material.navigation.NavigationView) {
         navView.setupWithNavController(navController)
     }
 
-    private fun setupListView(listView: RecyclerView) {
+    private fun setupListView(listView: androidx.recyclerview.widget.RecyclerView) {
         val context = requireContext()
-        val layoutManager = LinearLayoutManager(context)
-        val decoration = DividerItemDecoration(context, layoutManager.orientation)
+        val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
+        val decoration = androidx.recyclerview.widget.DividerItemDecoration(context, layoutManager.orientation)
         context.getDrawable(R.drawable.inset_divider)?.let {
             decoration.setDrawable(it)
             listView.addItemDecoration(decoration)
@@ -120,7 +120,7 @@ class ItemListFragment : CommonFragment(), ItemListView {
         listView.adapter = adapter
     }
 
-    private fun setupToolbar(toolbar: Toolbar, drawerLayout: DrawerLayout) {
+    private fun setupToolbar(toolbar: Toolbar, drawerLayout: androidx.drawerlayout.widget.DrawerLayout) {
         toolbar.navigationIcon = resources.getDrawable(R.drawable.ic_menu, null)
         toolbar.setNavigationContentDescription(R.string.menu_description)
         toolbar.navigationClicks().subscribe { drawerLayout.openDrawer(GravityCompat.START) }

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -47,7 +47,7 @@ import mozilla.lockbox.model.AccountViewModel
 import mozilla.lockbox.support.showAndRemove
 
 @ExperimentalCoroutinesApi
-class ItemListFragment : CommonFragment(), ItemListView {
+class ItemListFragment : Fragment(), ItemListView {
     private val compositeDisposable = CompositeDisposable()
     private val adapter = ItemListAdapter()
     private lateinit var spinner: Spinner

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -104,14 +104,14 @@ class ItemListFragment : Fragment(), ItemListView {
         }
     }
 
-    private fun setupNavigationView(navController: NavController, navView: com.google.android.material.navigation.NavigationView) {
+    private fun setupNavigationView(navController: NavController, navView: NavigationView) {
         navView.setupWithNavController(navController)
     }
 
-    private fun setupListView(listView: androidx.recyclerview.widget.RecyclerView) {
+    private fun setupListView(listView: RecyclerView) {
         val context = requireContext()
-        val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
-        val decoration = androidx.recyclerview.widget.DividerItemDecoration(context, layoutManager.orientation)
+        val layoutManager = LinearLayoutManager(context)
+        val decoration = DividerItemDecoration(context, layoutManager.orientation)
         context.getDrawable(R.drawable.inset_divider)?.let {
             decoration.setDrawable(it)
             listView.addItemDecoration(decoration)
@@ -120,7 +120,7 @@ class ItemListFragment : Fragment(), ItemListView {
         listView.adapter = adapter
     }
 
-    private fun setupToolbar(toolbar: Toolbar, drawerLayout: androidx.drawerlayout.widget.DrawerLayout) {
+    private fun setupToolbar(toolbar: Toolbar, drawerLayout: DrawerLayout) {
         toolbar.navigationIcon = resources.getDrawable(R.drawable.ic_menu, null)
         toolbar.setNavigationContentDescription(R.string.menu_description)
         toolbar.navigationClicks().subscribe { drawerLayout.openDrawer(GravityCompat.START) }

--- a/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
@@ -23,7 +23,7 @@ import mozilla.lockbox.presenter.LockedPresenter
 import mozilla.lockbox.presenter.LockedView
 import java.lang.Exception
 
-class LockedFragment : CommonFragment(), LockedView {
+class LockedFragment : Fragment(), LockedView {
     private val _unlockConfirmed = PublishSubject.create<Boolean>()
 
     companion object {

--- a/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
@@ -7,7 +7,7 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.view.WindowManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R

--- a/app/src/main/java/mozilla/lockbox/view/SettingFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/SettingFragment.kt
@@ -31,7 +31,7 @@ class SettingFragment : BackableFragment(), SettingView {
     private val sectionedAdapter = SectionedAdapter(
         R.layout.list_cell_setting_header,
         R.id.headerTitle,
-        adapter as androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>
+        adapter as RecyclerView.Adapter<RecyclerView.ViewHolder>
     )
 
     override fun onCreateView(
@@ -45,7 +45,7 @@ class SettingFragment : BackableFragment(), SettingView {
         val view = inflater.inflate(R.layout.fragment_setting, container, false)
 
         view.settingList.adapter = sectionedAdapter
-        val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
+        val layoutManager = LinearLayoutManager(context)
         view.settingList.layoutManager = layoutManager
 
         // Add one to account for viewType configuration in the SectionedAdapter

--- a/app/src/main/java/mozilla/lockbox/view/SettingFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/SettingFragment.kt
@@ -7,8 +7,8 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -31,7 +31,7 @@ class SettingFragment : BackableFragment(), SettingView {
     private val sectionedAdapter = SectionedAdapter(
         R.layout.list_cell_setting_header,
         R.id.headerTitle,
-        adapter as RecyclerView.Adapter<RecyclerView.ViewHolder>
+        adapter as androidx.recyclerview.widget.RecyclerView.Adapter<androidx.recyclerview.widget.RecyclerView.ViewHolder>
     )
 
     override fun onCreateView(
@@ -45,7 +45,7 @@ class SettingFragment : BackableFragment(), SettingView {
         val view = inflater.inflate(R.layout.fragment_setting, container, false)
 
         view.settingList.adapter = sectionedAdapter
-        val layoutManager = LinearLayoutManager(context)
+        val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context)
         view.settingList.layoutManager = layoutManager
 
         // Add one to account for viewType configuration in the SectionedAdapter

--- a/app/src/main/java/mozilla/lockbox/view/SettingViewHolder.kt
+++ b/app/src/main/java/mozilla/lockbox/view/SettingViewHolder.kt
@@ -24,7 +24,7 @@ import kotlinx.android.synthetic.main.list_cell_setting_toggle.view.toggle
 import mozilla.lockbox.R
 
 abstract class SettingViewHolder(override val containerView: View) :
-    androidx.recyclerview.widget.RecyclerView.ViewHolder(containerView),
+    RecyclerView.ViewHolder(containerView),
     LayoutContainer {
     var disposable: Disposable? = null
     abstract var contentDescription: Int

--- a/app/src/main/java/mozilla/lockbox/view/SettingViewHolder.kt
+++ b/app/src/main/java/mozilla/lockbox/view/SettingViewHolder.kt
@@ -6,8 +6,8 @@
 
 package mozilla.lockbox.view
 
-import android.support.annotation.StringRes
-import android.support.v7.widget.RecyclerView
+import androidx.annotation.StringRes
+import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import android.widget.Switch
 import com.jakewharton.rxbinding2.widget.checkedChanges
@@ -24,7 +24,7 @@ import kotlinx.android.synthetic.main.list_cell_setting_toggle.view.toggle
 import mozilla.lockbox.R
 
 abstract class SettingViewHolder(override val containerView: View) :
-    RecyclerView.ViewHolder(containerView),
+    androidx.recyclerview.widget.RecyclerView.ViewHolder(containerView),
     LayoutContainer {
     var disposable: Disposable? = null
     abstract var contentDescription: Int

--- a/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
@@ -17,7 +17,7 @@ import mozilla.lockbox.R
 import mozilla.lockbox.presenter.WelcomePresenter
 import mozilla.lockbox.presenter.WelcomeView
 
-class WelcomeFragment : CommonFragment(), WelcomeView {
+class WelcomeFragment : Fragment(), WelcomeView {
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/res/layout/activity_root.xml
+++ b/app/src/main/res/layout/activity_root.xml
@@ -4,7 +4,7 @@
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -20,4 +20,4 @@
         app:navGraph="@navigation/graph_main"
         app:defaultNavHost="true"
         />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -15,7 +15,7 @@
 
     <include layout="@layout/include_backable_filter"/>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/entriesView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_fingerprint_dialog.xml
+++ b/app/src/main/res/layout/fragment_fingerprint_dialog.xml
@@ -5,11 +5,11 @@
   -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                   xmlns:tools="http://schemas.android.com/tools"
-                                                   android:layout_width="wrap_content"
-                                                   android:layout_height="wrap_content"
-                                                   android:paddingTop="32dp">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingTop="32dp">
 
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_fingerprint_dialog.xml
+++ b/app/src/main/res/layout/fragment_fingerprint_dialog.xml
@@ -4,15 +4,15 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:paddingTop="32dp">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                                   xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                   xmlns:tools="http://schemas.android.com/tools"
+                                                   android:layout_width="wrap_content"
+                                                   android:layout_height="wrap_content"
+                                                   android:paddingTop="32dp">
 
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/constraintLayout"
         android:layout_width="280dp"
         android:layout_height="wrap_content"
@@ -107,7 +107,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/dialogTitle"
             tools:text="Give Lockbox permission to unlock this app with the fingerprint sensor." />
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ImageView
         android:id="@+id/iconLockbox"
@@ -120,4 +120,4 @@
         app:layout_constraintTop_toTopOf="@+id/constraintLayout"
         app:srcCompat="@drawable/ic_lockbox"
         tools:ignore="ContentDescription" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_fxa_login.xml
+++ b/app/src/main/res/layout/fragment_fxa_login.xml
@@ -6,7 +6,7 @@
   -->
 
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
@@ -31,4 +31,4 @@
             android:background="@android:color/holo_red_dark"
             app:layout_constraintBottom_toBottomOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -5,7 +5,7 @@
   ~  file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
@@ -14,7 +14,7 @@
         android:background="@color/backgroundGrey">
     <include layout="@layout/include_backable"/>
 
-    <android.support.v7.widget.CardView
+    <androidx.cardview.widget.CardView
             xmlns:card_view="http://schemas.android.com/apk/res-auto"
             android:id="@+id/card_view"
             android:layout_width="match_parent"
@@ -22,7 +22,7 @@
             android:layout_gravity="center"
             card_view:layout_constraintTop_toBottomOf="@id/toolbar">
 
-        <android.support.constraint.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingStart="16dp"
@@ -30,7 +30,7 @@
                 android:paddingEnd="16dp"
                 android:paddingBottom="26dp">
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/inputLayoutHostname"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -52,9 +52,9 @@
                         android:focusable="true"
                         tools:ignore="Autofill"/>
 
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/inputLayoutUsername"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -75,7 +75,7 @@
                         app:layout_constraintEnd_toEndOf="@+id/inputLayoutUsername"
                         app:layout_constraintTop_toTopOf="@+id/inputLayoutUsername"
                         tools:ignore="Autofill"/>
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <ImageButton
                     android:id="@+id/btnUsernameCopy"
@@ -91,7 +91,7 @@
                     tools:layout_editor_absoluteX="334dp"
                     tools:layout_editor_absoluteY="89dp"/>
 
-            <android.support.design.widget.TextInputLayout
+            <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/inputLayoutPassword"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -112,7 +112,7 @@
                         android:singleLine="true"
                         android:lineSpacingExtra="8sp"
                         tools:ignore="Autofill"/>
-            </android.support.design.widget.TextInputLayout>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <ImageButton
                     android:id="@+id/btnPasswordCopy"
@@ -139,9 +139,9 @@
                     app:layout_constraintTop_toTopOf="@+id/inputLayoutPassword"
                     app:srcCompat="@drawable/ic_show"/>
 
-        </android.support.constraint.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </android.support.v7.widget.CardView>
+    </androidx.cardview.widget.CardView>
 
     <TextView
             android:id="@+id/placeholder_learn"
@@ -161,4 +161,4 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_item_list.xml
+++ b/app/src/main/res/layout/fragment_item_list.xml
@@ -5,12 +5,12 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 <androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                           xmlns:app="http://schemas.android.com/apk/res-auto"
-                                           xmlns:tools="http://schemas.android.com/tools"
-                                           android:id="@+id/appDrawer"
-                                           android:layout_width="match_parent"
-                                           android:layout_height="match_parent"
-                                           tools:context=".view.ItemListFragment">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/appDrawer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.ItemListFragment">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_item_list.xml
+++ b/app/src/main/res/layout/fragment_item_list.xml
@@ -4,13 +4,13 @@
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
-<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/appDrawer"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".view.ItemListFragment">
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                                           xmlns:app="http://schemas.android.com/apk/res-auto"
+                                           xmlns:tools="http://schemas.android.com/tools"
+                                           android:id="@+id/appDrawer"
+                                           android:layout_width="match_parent"
+                                           android:layout_height="match_parent"
+                                           tools:context=".view.ItemListFragment">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -18,7 +18,7 @@
         android:fitsSystemWindows="false"
         android:orientation="vertical">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
                 android:id="@+id/navToolbar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
@@ -54,19 +54,19 @@
                         android:layout_marginEnd="16dp"
                         style="@style/ToolbarButton"/>
             </LinearLayout>
-        </android.support.v7.widget.Toolbar>
+        </androidx.appcompat.widget.Toolbar>
 
-        <android.support.v4.widget.SwipeRefreshLayout
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             xmlns:android="http://schemas.android.com/apk/res/android"
             android:id="@+id/refreshContainer"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-            <android.support.v7.widget.RecyclerView
+            <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/entriesView"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
-        </android.support.v4.widget.SwipeRefreshLayout>
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
         <RelativeLayout
             android:id="@+id/loadingView"
@@ -116,7 +116,7 @@
         </RelativeLayout>
     </LinearLayout>
 
-    <android.support.design.widget.NavigationView
+    <com.google.android.material.navigation.NavigationView
         android:id="@+id/navView"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
@@ -152,5 +152,5 @@
                 android:textColor="@color/textGrey"
                 android:theme="@style/NavDrawerButtonStyle" />
         </LinearLayout>
-    </android.support.design.widget.NavigationView>
-</android.support.v4.widget.DrawerLayout>
+    </com.google.android.material.navigation.NavigationView>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/fragment_locked.xml
+++ b/app/src/main/res/layout/fragment_locked.xml
@@ -5,7 +5,7 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -49,4 +49,4 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -4,7 +4,7 @@
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -15,7 +15,7 @@
 
     <include layout="@layout/include_backable"/>
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/settingList"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -24,4 +24,4 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_webview.xml
+++ b/app/src/main/res/layout/fragment_webview.xml
@@ -5,7 +5,7 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -27,4 +27,4 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_welcome.xml
+++ b/app/src/main/res/layout/fragment_welcome.xml
@@ -4,7 +4,7 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -74,4 +74,4 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textViewInstructions" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/include_backable.xml
+++ b/app/src/main/res/layout/include_backable.xml
@@ -2,8 +2,8 @@
 
 
 <androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
-                                   android:id="@+id/toolbar"
-                                   android:layout_width="match_parent"
-                                   android:layout_height="?attr/actionBarSize"
-                                   android:background="?attr/colorPrimary"
-                                   android:theme="@style/ToolBar" />
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="?attr/colorPrimary"
+    android:theme="@style/ToolBar" />

--- a/app/src/main/res/layout/include_backable.xml
+++ b/app/src/main/res/layout/include_backable.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 
-<android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/toolbar"
-    android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
-    android:background="?attr/colorPrimary"
-    android:theme="@style/ToolBar" />
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+                                   android:id="@+id/toolbar"
+                                   android:layout_width="match_parent"
+                                   android:layout_height="?attr/actionBarSize"
+                                   android:background="?attr/colorPrimary"
+                                   android:theme="@style/ToolBar" />

--- a/app/src/main/res/layout/include_backable_filter.xml
+++ b/app/src/main/res/layout/include_backable_filter.xml
@@ -5,12 +5,12 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 <androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
-                                   xmlns:tools="http://schemas.android.com/tools"
-                                   android:id="@+id/toolbar"
-                                   android:layout_width="match_parent"
-                                   android:layout_height="?attr/actionBarSize"
-                                   android:background="?attr/colorPrimary"
-                                   android:theme="@style/ToolBar">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="?attr/colorPrimary"
+    android:theme="@style/ToolBar">
     <LinearLayout android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/app/src/main/res/layout/include_backable_filter.xml
+++ b/app/src/main/res/layout/include_backable_filter.xml
@@ -4,13 +4,13 @@
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
-<android.support.v7.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/toolbar"
-    android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
-    android:background="?attr/colorPrimary"
-    android:theme="@style/ToolBar">
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+                                   xmlns:tools="http://schemas.android.com/tools"
+                                   android:id="@+id/toolbar"
+                                   android:layout_width="match_parent"
+                                   android:layout_height="?attr/actionBarSize"
+                                   android:background="?attr/colorPrimary"
+                                   android:theme="@style/ToolBar">
     <LinearLayout android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -42,4 +42,4 @@
             android:contentDescription="@string/search_clear_content_description" />
     </LinearLayout>
 
-</android.support.v7.widget.Toolbar>
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/layout/include_nessie.xml
+++ b/app/src/main/res/layout/include_nessie.xml
@@ -12,7 +12,7 @@
     android:layout_height="match_parent"
     tools:showIn="@layout/fragment_welcome">
 
-    <android.support.constraint.ConstraintLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/nessie_constraint_layout"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -54,7 +54,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/logo" />
 
-    </android.support.constraint.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ImageView
         android:id="@+id/nessie"

--- a/app/src/main/res/layout/list_cell_item.xml
+++ b/app/src/main/res/layout/list_cell_item.xml
@@ -5,7 +5,7 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -57,4 +57,4 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         tools:ignore="ContentDescription" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_cell_setting_toggle.xml
+++ b/app/src/main/res/layout/list_cell_setting_toggle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -77,4 +77,4 @@
         app:layout_constraintTop_toBottomOf="@id/subtitle"
         app:layout_constraintStart_toStartOf="@id/title"
         tools:text="@string/learn_more"/>
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_cell_setting_toggle.xml
+++ b/app/src/main/res/layout/list_cell_setting_toggle.xml
@@ -33,7 +33,7 @@
         app:layout_constraintBottom_toBottomOf="@id/title"
         app:layout_constraintEnd_toEndOf="parent"/>
 
-    <android.support.constraint.Barrier
+    <androidx.constraintlayout.widget.Barrier
         android:id="@+id/barrier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/test/java/mozilla/lockbox/ObservableExtensionTest.kt
+++ b/app/src/test/java/mozilla/lockbox/ObservableExtensionTest.kt
@@ -62,19 +62,20 @@ class ObservableExtensionTest {
     @Test
     fun debug() {
         val subject = PublishSubject.create<String>()
-        subject.debug().subscribe({}, {})
+        val observer = "OBSERVER"
+        subject.debug(observer).subscribe({}, {})
 
-        verify(logger).info("subscribed")
+        verify(logger).info("$observer: subscribed")
 
         val eventMessage = "message"
         subject.onNext(eventMessage)
 
-        verify(logger).info("event: $eventMessage")
+        verify(logger).info("$observer: event: $eventMessage")
 
         val errorMessage = "error_message"
         val error = Throwable(message = errorMessage)
         subject.onError(error)
 
-        verify(logger).info("error: $errorMessage")
+        verify(logger).info("$observer: error: $errorMessage")
     }
 }

--- a/app/src/test/java/mozilla/lockbox/adapter/ItemListAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/ItemListAdapterTest.kt
@@ -7,8 +7,8 @@
 package mozilla.lockbox.adapter
 
 import android.content.Context
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import mozilla.lockbox.model.ItemViewModel
 import mozilla.lockbox.view.ItemViewHolder
 import org.junit.Assert

--- a/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.adapter
 
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver

--- a/app/src/test/java/mozilla/lockbox/adapter/SectionedAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/SectionedAdapterTest.kt
@@ -7,8 +7,8 @@
 package mozilla.lockbox.adapter
 
 import android.content.Context
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import android.widget.LinearLayout
 import mozilla.lockbox.R
 import mozilla.lockbox.adapter.SectionedAdapter.Section

--- a/app/src/test/java/mozilla/lockbox/adapter/SettingListAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/SettingListAdapterTest.kt
@@ -7,8 +7,8 @@
 package mozilla.lockbox.adapter
 
 import android.content.Context
-import android.support.v7.widget.LinearLayoutManager
-import android.support.v7.widget.RecyclerView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import mozilla.lockbox.BuildConfig
 import mozilla.lockbox.R
 import mozilla.lockbox.adapter.SettingListAdapter.Companion.SETTING_TEXT_TYPE

--- a/app/src/test/java/mozilla/lockbox/presenter/ApplicationPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ApplicationPresenterTest.kt
@@ -6,9 +6,9 @@
 
 package mozilla.lockbox.presenter
 
-import android.arch.lifecycle.Lifecycle
-import android.arch.lifecycle.LifecycleObserver
-import android.arch.lifecycle.LifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.flux.Action

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -6,7 +6,7 @@
 
 package mozilla.lockbox.presenter
 
-import android.support.annotation.StringRes
+import androidx.annotation.StringRes
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject

--- a/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
@@ -109,7 +109,7 @@ class AutoLockStoreTest {
         PowerMockito.whenNew(SimpleFileReader::class.java).withAnyArguments().thenReturn(fileReader)
 
         subject.injectContext(context)
-        subject.activateAutoLockMEGAZORD.subscribe(lockRequiredObserver)
+        subject.autoLockActivated.subscribe(lockRequiredObserver)
         subject.lockingSupport = lockingSupport
     }
 

--- a/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
@@ -245,7 +245,7 @@ class AutoLockStoreTest {
 
         clearInvocations(preferences)
         clearInvocations(editor)
-        Dispatcher.shared.dispatch(DataStoreAction.Lock)
+        dispatcher.dispatch(DataStoreAction.Lock)
 
         verify(preferences).edit()
 
@@ -270,9 +270,8 @@ class AutoLockStoreTest {
 
         clearInvocations(preferences)
         clearInvocations(editor)
-        Dispatcher.shared.dispatch(DataStoreAction.Lock)
+        dispatcher.dispatch(DataStoreAction.Lock)
 
-        verifyZeroInteractions(preferences)
         verifyZeroInteractions(editor)
     }
 

--- a/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
@@ -83,7 +83,7 @@ class AutoLockStoreTest {
 
     private var bootID = ";kl;jjkloi;kljhafshjkadfsmn"
 
-    private val lockRequiredObserver: TestObserver<Boolean> = TestObserver.create()
+    private val lockRequiredObserver: TestObserver<Unit> = TestObserver.create()
 
     private val lockingSupport = spy(TestLockingSupport())
 
@@ -106,7 +106,7 @@ class AutoLockStoreTest {
         PowerMockito.whenNew(SimpleFileReader::class.java).withAnyArguments().thenReturn(fileReader)
 
         subject.injectContext(context)
-        subject.timerExpired.subscribe(lockRequiredObserver)
+        subject.activateAutoLockMEGAZORD.subscribe(lockRequiredObserver)
         subject.lockingSupport = lockingSupport
     }
 
@@ -219,7 +219,7 @@ class AutoLockStoreTest {
 
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Foreground)
 
-        lockRequiredObserver.assertLastValue(false)
+        lockRequiredObserver.assertLastValue(Unit)
     }
 
     @Test
@@ -228,14 +228,14 @@ class AutoLockStoreTest {
 
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Foreground)
 
-        lockRequiredObserver.assertLastValue(true)
+        lockRequiredObserver.assertLastValue(Unit)
     }
 
     @Test
     fun `datastore locking actions, when locking is not required by autolock, force the autolocktimerdate to an older time`() {
         mockSavedValues(SystemClock.elapsedRealtime() + 600000)
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Foreground)
-        lockRequiredObserver.assertLastValue(false)
+        lockRequiredObserver.assertLastValue(Unit)
 
         clearInvocations(preferences)
         clearInvocations(editor)
@@ -259,7 +259,7 @@ class AutoLockStoreTest {
     fun `datastore locking actions, when locking is required by autolock, do nothing`() {
         mockSavedValues(SystemClock.elapsedRealtime() - 600000)
         (lifecycleStore.lifecycleEvents as Subject).onNext(LifecycleAction.Foreground)
-        lockRequiredObserver.assertLastValue(true)
+        lockRequiredObserver.assertLastValue(Unit)
 
         clearInvocations(preferences)
         clearInvocations(editor)

--- a/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/AutoLockStoreTest.kt
@@ -106,7 +106,7 @@ class AutoLockStoreTest {
         PowerMockito.whenNew(SimpleFileReader::class.java).withAnyArguments().thenReturn(fileReader)
 
         subject.injectContext(context)
-        subject.lockRequired.subscribe(lockRequiredObserver)
+        subject.timerExpired.subscribe(lockRequiredObserver)
         subject.lockingSupport = lockingSupport
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
     ext.navigation_version = '1.0.0-alpha09'
     ext.rxbinding_version = '2.2.0'
     ext.coroutine_version = '1.0.1'
+    ext.androidxTest_version = '1.1.0'
 
     repositories {
         google()

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -18,7 +18,7 @@ The most important accessibility warning is the `contentDescription` warning on 
 
 When adding new Espresso tests, you may notice failures related to things like
 tap target size. The automated Espresso accessibility checks occur on every
-method call in the [`ViewActions`](https://developer.android.com/reference/android/support/test/espresso/action/ViewActions) class.
+method call in the [`ViewActions`](https://developer.android.com/reference/androidx.test/espresso/action/ViewActions) class.
 
 ## Manual Accessibility Testing
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
There are serveral parts to this, each of which is slow and difficult. 

 - [x] Ensure that the AutoLockTests work.
 - [x] Write failing new tests for the Locking edge cases
 - [x] Correct the application code such that the new tests and `AutoLockTests` all work.

This PR: 
 * updates the use of the android support library to androidx.
 * stabilizes a lot of tests by moving to the AndroidX Test Coordinator. 
 * re-writes `AutoLockStore` to broadcast the need for locking, rather than autolocking would fire here if it needed here. This makes auto locking a little more encapsulated.
 * `AutoLockStoreTest` needed changing in order to make that work.
 * It also moves a lot of logic out of the `RoutePresenter` to the various stores.
    - `DataStore`
    - `RouteStore`
    - `AutoLockStore`

Fixes #260