### PR TITLE
credential provider infrastructure

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,21 +6,21 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="mozilla.lockbox">
+          xmlns:tools="http://schemas.android.com/tools" package="mozilla.lockbox">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
     <application
-        xmlns:tools="http://schemas.android.com/tools"
-        android:allowBackup="false"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:name=".LockboxApplication"
-        tools:replace="android:allowBackup">
+            xmlns:tools="http://schemas.android.com/tools"
+            android:allowBackup="false"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsRtl="true"
+            android:theme="@style/AppTheme"
+            android:name=".LockboxApplication"
+            tools:replace="android:allowBackup" tools:ignore="GoogleAppIndexingWarning">
         <activity
             android:name=".view.RootActivity"
             android:label="@string/app_label"
@@ -33,5 +33,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+                android:name=".LockboxAutofillService"
+                android:label="Lockbox"
+                android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService" />
+            </intent-filter>
+        </service>
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,13 @@
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools" package="mozilla.lockbox">
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+<manifest
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        package="mozilla.lockbox">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
 
     <application
             xmlns:tools="http://schemas.android.com/tools"
@@ -20,17 +22,18 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
             android:name=".LockboxApplication"
-            tools:replace="android:allowBackup" tools:ignore="GoogleAppIndexingWarning">
+            tools:replace="android:allowBackup"
+            tools:ignore="GoogleAppIndexingWarning">
         <activity
-            android:name=".view.RootActivity"
-            android:label="@string/app_label"
-            android:windowSoftInputMode="adjustResize"
-            android:configChanges="orientation|keyboardHidden"
-            android:screenOrientation="portrait">
+                android:name=".view.RootActivity"
+                android:label="@string/app_label"
+                android:windowSoftInputMode="adjustResize"
+                android:configChanges="orientation|keyboardHidden"
+                android:screenOrientation="portrait">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
 
@@ -39,7 +42,7 @@
                 android:label="Lockbox"
                 android:permission="android.permission.BIND_AUTOFILL_SERVICE">
             <intent-filter>
-                <action android:name="android.service.autofill.AutofillService" />
+                <action android:name="android.service.autofill.AutofillService"/>
             </intent-filter>
         </service>
     </application>

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -1,0 +1,22 @@
+package mozilla.lockbox
+
+import android.annotation.SuppressLint
+import android.os.CancellationSignal
+import android.service.autofill.AutofillService
+import android.service.autofill.FillCallback
+import android.service.autofill.FillRequest
+import android.service.autofill.SaveCallback
+import android.service.autofill.SaveRequest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.store.DataStore
+
+@ExperimentalCoroutinesApi
+@SuppressLint("NewApi")
+class LockboxAutofillService(
+    val dataStore: DataStore = DataStore.shared
+) : AutofillService() {
+
+    override fun onFillRequest(request: FillRequest, cancellationSignal: CancellationSignal, callback: FillCallback) {}
+
+    override fun onSaveRequest(request: SaveRequest, callback: SaveCallback) {}
+}

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -1,6 +1,7 @@
 package mozilla.lockbox
 
-import android.annotation.SuppressLint
+import android.annotation.TargetApi
+import android.os.Build
 import android.os.CancellationSignal
 import android.service.autofill.AutofillService
 import android.service.autofill.FillCallback
@@ -10,8 +11,8 @@ import android.service.autofill.SaveRequest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.store.DataStore
 
+@TargetApi(Build.VERSION_CODES.O)
 @ExperimentalCoroutinesApi
-@SuppressLint("NewApi")
 class LockboxAutofillService(
     val dataStore: DataStore = DataStore.shared
 ) : AutofillService() {


### PR DESCRIPTION
Fixes #214 

## Testing and Review Notes

Note that nothing will actually get "suggested" or populated at this time, we're purely tracking the infrastructure and setup. However, Lockbox will appear as an available credential provider in settings.

Testing steps:
- Ran the app, selected Lockbox as a credential provider
- Navigated to login screen (twitter.com, via Focus)
- Checked `DataStore.shared` memory location from `LockboxAutofillService::onConnected` against `RoutePresenter::onViewReady` ✅ 
- Hard quit app
- Made sure `DataStore.shared` is still accessible in `LockboxAutofillService::onConnected` ✅ 

I don't know what credential management will look like in the `AutofillService`. Presumably, we just won't be able to `sync` unless we're in an app context, and don't need to handle that case in the `Service`. I also haven't done anything with Datastore data or state beyond checking that it's present; we may need to pull in something like the `AutoLockStore` to manage locked state. 

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
