### PR TITLE
Use 'org.mozilla.appservices' Gradle plugin to consume single megazor…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'kotlin-android-extensions'
     id 'kotlin-android'
     id 'io.sentry.android.gradle'
+    id 'org.mozilla.appservices'
 }
 
 android {
@@ -118,6 +119,12 @@ dependencies {
     }
     androidTestImplementation 'br.com.concretesolutions:kappuccino:1.2.1'
     ktlint "com.github.shyiko:ktlint:0.28.0"
+}
+
+appservices {
+    defaultConfig {
+        megazord = 'lockbox'
+    }
 }
 
 def outputDir = "${project.buildDir}/reports/ktlint/"

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -13,6 +13,7 @@ import com.squareup.leakcanary.LeakCanary
 import io.sentry.Sentry
 import io.sentry.android.AndroidSentryClientFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.appservices.LockboxMegazord
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.base.log.sink.AndroidLogSink
@@ -53,6 +54,8 @@ class LockboxApplication : Application() {
     }
 
     private fun setupDataStoreSupport() {
+        LockboxMegazord.init()
+
         // this needs to be done after injectContext, as
         // SyncDataStoreSupport needs to find the database
         // path from the context

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.10'
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$navigation_version"
+        classpath 'org.mozilla.appservices:gradle-plugin:0.2.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
…d lib. (#352)

Fixes #352
Fixes #242

Related to #242, #337

I notice that Lockbox is currently configured for x86_64, but I don't think that a-s is producing any x86_64 binaries: https://github.com/mozilla/application-services/issues/426.  If we're confident that x86_64 support is needed, this is blocked by that ticket.  If not, I think we can land this without x86_64 support, since it's the status quo.

## Testing and Review Notes

This follows the [Reference Browser model](https://github.com/mozilla-mobile/reference-browser/pull/318) and [the documentation](https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html).

This needs to be tested (manually, or on emulators that actually open SQLite DBs) on devices of different architectures:

- [x] armeabi-v7a
- [x] arm64-v8a
- [ ] x86
- [ ] maybe x86_64 (see above)

It works fine on my armeabi-v7a device (an old Galaxy S6, I think).
