### PR TITLE
Add release instructions

### DIFF
--- a/app/src/main/res/layout/list_cell_setting_appversion.xml
+++ b/app/src/main/res/layout/list_cell_setting_appversion.xml
@@ -23,4 +23,5 @@
         android:lineSpacingExtra="6sp"
         android:layout_marginTop="16dp"
         tools:text="App Version: 1.0"/>
+    <!-- Set the tools:text value to match versionName from build.gradle -->
 </LinearLayout>

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,7 @@
+# Release Notes
+
+## 1.0 (Build 2050)
+
+_Date: 2019-01-08_
+
+First internal Alpha release on Play Store

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,82 @@
+# Release Instructions
+
+Some assumptions:
+
+- `master` is the default branch and is production-ready
+- commits made to `master` are built and pass in [bitrise][1]
+- bitrise will test, build, and sign the APK for every build on every branch
+- `production` is our public release branch and may not match `master`
+  - ideally, `production` will perfectly reproduce master
+  - but if `master` is in an un-releasable state, we cherry-pick commits to this branch
+  - this is an exception rather than the preferred maintenance method
+- no automated uploads to Google Play Console occur, manual artifact uploads (from bitrise's signed artifacts) are required for internal, closed, open, and production releases
+- Play Store has Internal (core team, email-restricted), Alpha (closed, email-restricted), and Production (everyone!) release channels configured
+  - currently, no plans exist for "external" testers nor "Open" release channels
+  - in the future we may create an open Beta testing channel to allow anyone outside of Mozilla to help us test in-progress work
+
+## Distributing Builds through bitrise (primary = branch, deploy = master)
+
+_all commits on all branches and pull requests are automatically built_
+
+1. Push to the git branch available on GitHub.com and open a pull request
+2. Open [bitrise][1] from a mobile device and browse to the build
+  - bitrise access is currently private and email-restricted
+
+## Preparing a Release (for Internal, Alpha, or Production via Play Store)
+
+1. Update the release notes under `docs/release-notes.md`
+  - create a pull request to collaborate and get approval
+  - determine the next build number and include it in release notes
+  - merge the release notes to `master` branch
+  - this will result in a release build matching the build number provided
+2. Create and merge a pull request _from_ `master` _to_ `production` so it tracks the release
+  - https://github.com/mozilla-lockbox/lockbox-android/compare/production...master
+3. Create a tag from `production` matching the format: `major.minor.patch.build`
+  - for example: `1.2.1399` is major version 1.2, bitrise build 1399
+  - for example: `1.3.1.1624` is major version 1.3 with 1 patch release, (bitrise) build 1624
+  - `git tag -a -s 1.3.1.1624 -m "1.3.1 (Build 1624)"`
+4. push the tag to GitHub and create a corresponding "Release" on GitHub.com
+  - copy the release notes to the "Release" on GitHub
+  - download the `-signed.apk` from bitrise and attach it to the Release on GitHub
+5. Upload the `-signed.apk` (from bitrise) to the [Play Console][2]:
+  - browse to "Release Management" > "App Releases" > "Internal test track" > "Manage"
+  - "Create Release" and upload the signed APK, set the version to match the tag (for example: `1.2.1339`) then "Review" and the build will be immediately available to the core team
+6. Continue the "Distributing..." instructions
+
+### In Case of Emergency (Release)
+
+_similar to above, but requires explicit cherry-pick commits on `production` branch when `master` branch is not in a release-able state_
+
+1. Merge the emergency changes or fixes or features to default `master` branch as usual
+2. Update the release notes
+3. Create and merge a pull request _up to and including_ the last release-able commit on `master` to `production`
+4. Then `git cherry-pick` each additional commit from `master` to be included in the release
+  - thus skipping or avoiding the non-release-able commits
+5. Push the resulting `production` branch to GitHub.com
+6. Create a tag from `production` matching the format: `major.minor.patch.build`
+  - for example: `git tag -a -s 1.3.1.1624 -m "1.3.1 (Build 1624)"`
+7. Push the tag to GitHub and create a corresponding "Release" on GitHub.com
+  - copy the release notes to the "Release" on GitHub
+8. Browse to bitrise and find the desired `production` branch build to distribute
+  - download the `.signed-apk` and attach it to the Release on GitHub
+9. Upload the `-signed.apk` (from bitrise) to the [Play Console][2]:
+  - browse to "Release Management" > "App Releases" > "Internal test track" > "Manage"
+  - "Create Release" and upload the signed APK, set the version to match the tag (for example: `1.2.1339`) then "Review" and the build will be immediately available to the core team
+10. Continue the "Distributing..." instructions
+
+## Distributing Builds through Play Store (Internal, Alpha)
+
+_all builds must be manually uploaded from bitrise to Play Store Console as an artifact aka "New Release" in the "Preparing" instructions above_
+
+1. Browse to [App Releases][2] in Play Console
+2. Browse to the "Internal test track" (this release should already be uploaded and available to the core Lockbox team)
+3. Promote the release to the (internal still) Alpha channel using the "Promote to Alpha" button, complete the questions
+
+## Distributing through the App Store (Production)
+
+1. Contact release management...
+
+NOTE: _brand new_ apps may take 1 or more hours to appear in the Play Store whereas existing app (updates) can appear within minutes. Schedule accordingly!
+
+[1]: https://app.bitrise.io/app/20089a88380dd14d
+[2]: https://play.google.com/apps/publish/?account=7083182635971239206#ManageReleasesPlace:p=mozilla.lockbox&appid=4972100280256015711

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -78,5 +78,12 @@ _all builds must be manually uploaded from bitrise to Play Store Console as an a
 
 NOTE: _brand new_ apps may take 1 or more hours to appear in the Play Store whereas existing app (updates) can appear within minutes. Schedule accordingly!
 
+## Updating the version
+
+_Once a version has been merged or released, the major app version should be increased_
+
+- Update the `versionCode` and `versionName` values in `app/build.gradle`
+- Also update the value in the `list_cell_setting_appversion.xml` layout to _the exact same version_
+
 [1]: https://app.bitrise.io/app/20089a88380dd14d
 [2]: https://play.google.com/apps/publish/?account=7083182635971239206#ManageReleasesPlace:p=mozilla.lockbox&appid=4972100280256015711

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,3 +14,4 @@ pages:
   - 'Flux Architecture': 'architecture/flux.md'
   - 'Using Keys and Biometrics': 'architecture/sec-apis.md'
   - 'Accessibility': 'accessibility.md'
+  - 'Release Instructions': 'releases.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,12 +6,15 @@ repo_url: https://github.com/mozilla-lockbox/lockbox-android
 
 pages:
 - 'Introduction': 'index.md'
-- 'Contributing': 'contributing.md'
 - 'Release Notes': 'release-notes.md'
+- 'How to Contribute': 
+  - 'Contributing': 'contributing.md'
+  - 'Code of Conduct': 'code_of_conduct.md'
 - 'Telemetry and Metrics': 'metrics.md'
 - 'Developer Guides':
   - 'Build and Install': 'install.md'
   - 'Flux Architecture': 'architecture/flux.md'
   - 'Using Keys and Biometrics': 'architecture/sec-apis.md'
   - 'Accessibility': 'accessibility.md'
+  - 'Test Plan': 'test-plan.md'
   - 'Release Instructions': 'releases.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ repo_url: https://github.com/mozilla-lockbox/lockbox-android
 pages:
 - 'Introduction': 'index.md'
 - 'Contributing': 'contributing.md'
+- 'Release Notes': 'release-notes.md'
 - 'Telemetry and Metrics': 'metrics.md'
 - 'Developer Guides':
   - 'Build and Install': 'install.md'


### PR DESCRIPTION
Closes #111

This is based on everything I went through twice today in the Play Console and basically mimics our iOS release process as much as possible (no auto uploads now but no biggie).

I poked around a bit and think the version number in our settings view is fine as-is but appreciate someone double checking that instruction/note are OK.