### PR TITLE
Fix support text box which is overlapping the toggle. (#362)

### DIFF
--- a/app/src/main/res/layout/list_cell_setting_toggle.xml
+++ b/app/src/main/res/layout/list_cell_setting_toggle.xml
@@ -23,6 +23,26 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Send Usage Data"/>
 
+    <Switch
+        android:id="@+id/toggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="18dp"
+        android:thumbTint="@color/switch_thumb_color"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:layout_constraintBottom_toBottomOf="@id/title"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <android.support.constraint.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="title, toggle"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <TextView
         android:id="@+id/subtitle"
         android:layout_width="0dp"
@@ -35,20 +55,10 @@
         android:textStyle="normal"
         android:layout_marginStart="16dp"
         android:paddingTop="2dp"
-        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/barrier"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintWidth_max="300dp"
         tools:text="Mozilla strives to only collect what we need to provide and improve Firefox for everyone." />
-
-    <Switch
-        android:id="@+id/toggle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="18dp"
-        android:thumbTint="@color/switch_thumb_color"
-        app:layout_constraintTop_toTopOf="@id/title"
-        app:layout_constraintBottom_toBottomOf="@id/title"
-        app:layout_constraintEnd_toEndOf="parent"/>
 
     <Button
         android:id="@+id/button"


### PR DESCRIPTION
Fixes #362 

## Testing and Review Notes

- Overlapping happened on devices with a low resolution.
- Use `Barrier` to prevent subtitle text overlapping on toggle button.

## Screenshots or Videos

![image](https://user-images.githubusercontent.com/6141401/51037157-6a368800-15ea-11e9-92a6-d1f0120c525a.png)

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [X] double check the original issue to confirm it is fully satisfied
- [X] add testing notes and screenshots in PR description to help guide reviewers
- [X] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [X] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI

Thank you!