### PR TITLE
WIP - example unit test that invokes Application Services native code.

### DIFF
--- a/app/src/test/java/mozilla/lockbox/store/AsyncLoginsStorageTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/AsyncLoginsStorageTest.kt
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.lockbox.store
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.plus
+import mozilla.appservices.logins.DatabaseLoginsStorage
+import mozilla.appservices.logins.LoginsStorage
+import mozilla.appservices.logins.MemoryLoginsStorage
+import mozilla.components.concept.storage.SyncError
+import mozilla.components.concept.storage.SyncOk
+import mozilla.components.concept.storage.SyncStatus
+import mozilla.components.concept.storage.SyncableStore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+import mozilla.components.service.sync.logins.AsyncLoginsStorageAdapter
+import mozilla.components.service.sync.logins.ServerPassword
+
+import mozilla.appservices.LockboxMegazord
+
+@RunWith(RobolectricTestRunner::class)
+class AsyncLoginsStorageTest {
+    private val testMainScope = CoroutineScope(newSingleThreadContext("Test"))
+
+    companion object {
+        @BeforeClass @JvmStatic fun `configure native library names`() {
+            // We must configure the library path names, 'cuz Robolectric
+            // does not invoke `Application.onCreate`.
+            LockboxMegazord.init()
+        }
+    }
+
+    @Test
+    fun `can do some stuff`() {
+
+        AsyncLoginsStorageAdapter.forDatabase(File("/tmp/path").canonicalPath).use { storage ->
+
+        runBlocking(testMainScope.coroutineContext) {
+
+                    storage.unlock("").await()
+
+
+                    val list1 = storage.list().await()
+                assertEquals(0, list1.size)
+
+        storage.add(ServerPassword(
+                id = "aaaaaaaaaaaa",
+                hostname = "https://www.example.com",
+                httpRealm = "Something",
+                username = "Foobar2000",
+                password = "hunter2",
+                usernameField = "users_name",
+                passwordField = "users_password"
+                                 )).await()
+
+                    val list2 = storage.list().await()
+                assertEquals(1, list2.size)
+
+                    storage.wipe().await()
+
+                    val list3 = storage.list().await()
+                assertEquals(0, list3.size)
+
+            storage.close()
+                }
+            }
+    }
+}


### PR DESCRIPTION
Three notes:

1. The `LockboxMegazord.init()` invocation is critical.  Without it,
the code will look for `liblogins_ffi.so`, not `liblockbox.so`.

2. The FxA code can't really be meaningfully unit-tested, because
there's no Android WebView at the other end.  Maybe that doesn't
matter?  I saw a comment ("note:
further FxA-related tests on hold until we can use x-compiled Rust
code in unit specs") in `AccountStoreTest.kt` that requires more
investigation.

3. Sorry the formatting -- I don't have a Kotlin mode in Emacs yet, so
you'll have to reformat as you edit this.

See also https://github.com/mozilla-mobile/android-components/pull/1713.

Fixes #???

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

Connected to #???

_(Optional: other issues or pull requests related to this, but merging should not close it)_

## Testing and Review Notes

_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_


## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
