### PR TITLE
Upgrade to A-C 0.38.0

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -174,7 +174,7 @@ open class DataStore(
             return
         }
         clearList()
-        backend.reset()
+        backend.wipeLocal()
             .asSingle(coroutineContext)
             .map { State.Unprepared }
             .subscribe(stateSubject::onNext, this::pushError)
@@ -216,7 +216,7 @@ open class DataStore(
         if (stateSubject.value != State.Unprepared &&
             stateSubject.value != null
         ) {
-            backend.reset()
+            backend.wipeLocal()
                 .asSingle(coroutineContext)
                 .subscribe()
                 .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -114,25 +114,19 @@ open class DataStore(
     }
 
     private fun unlock() {
-        if (backend.isLocked()) {
-            backend.unlock(support.encryptionKey)
-                .asSingle(coroutineContext)
-                .map { State.Unlocked }
-                .subscribe(stateSubject::onNext, this::pushError)
-                .addTo(compositeDisposable)
-        }
+        backend.ensureUnlocked(support.encryptionKey)
+            .asSingle(coroutineContext)
+            .map { State.Unlocked }
+            .subscribe(stateSubject::onNext, this::pushError)
+            .addTo(compositeDisposable)
     }
 
     private fun lock() {
-        if (!backend.isLocked()) {
-            backend.lock()
-                .asSingle(coroutineContext)
-                .map { State.Locked }
-                .subscribe(stateSubject::onNext, this::pushError)
-                .addTo(compositeDisposable)
-        } else {
-            stateSubject.onNext(State.Locked)
-        }
+        backend.ensureLocked()
+            .asSingle(coroutineContext)
+            .map { State.Locked }
+            .subscribe(stateSubject::onNext, this::pushError)
+            .addTo(compositeDisposable)
     }
 
     private fun sync() {

--- a/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
+++ b/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
@@ -40,8 +40,21 @@ open class MockLoginsStorage : LoginsStorage {
     override fun lock() {
         this._locked = true
     }
+    override fun ensureLocked() {
+        this._locked = true
+    }
 
     override fun unlock(encryptionKey: String) {
+        this._locked = false
+    }
+    override fun unlock(encryptionKey: ByteArray) {
+        this._locked = false
+    }
+    override fun ensureUnlocked(encryptionKey: String) {
+        this._locked = false
+    }
+
+    override fun ensureUnlocked(encryptionKey: ByteArray) {
         this._locked = false
     }
 
@@ -52,6 +65,8 @@ open class MockLoginsStorage : LoginsStorage {
     override fun reset() {}
 
     override fun wipe() {}
+
+    override fun wipeLocal() {}
 }
 
 class MockDataStoreSupport : DataStoreSupport {

--- a/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/DataStoreTest.kt
@@ -76,7 +76,7 @@ class DataStoreTest : DisposingTest() {
         Assert.assertEquals(State.Unprepared, stateIterator.next())
         Assert.assertEquals(0, listIterator.next().size)
 
-        verify(support.storage).reset()
+        verify(support.storage).wipeLocal()
     }
 
     @Test
@@ -110,7 +110,7 @@ class DataStoreTest : DisposingTest() {
         Assert.assertEquals(State.Unlocked, stateIterator.next())
 
         this.subject.resetSupport(MockDataStoreSupport())
-        verify(newSupport.storage).reset()
+        verify(newSupport.storage).wipeLocal()
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@
 buildscript {
     ext.android_support_version = '28.0.0'
     ext.kotlin_version = '1.3.0'
-    ext.android_components_version = '0.37.0'
+    ext.android_components_version = '0.38.0'
     ext.lifecycle_version = '1.1.1'
     ext.navigation_version = '1.0.0-alpha09'
     ext.rxbinding_version = '2.2.0'


### PR DESCRIPTION
Upgrades `android-components` to `0.38.0`, providing most of the changes requested to sync-logins and FxA.

Fixes #277
Fixes #312

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

Connected to #185
Connected to #286

_(Optional: other issues or pull requests related to this, but merging should not close it)_

## Testing and Review Notes

All existing tests pass and application continues to function as expected.

## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI