### PR TITLE
allow screenshots on debug builds

### DIFF
--- a/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
@@ -12,6 +12,7 @@ import android.view.WindowManager
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.RoutePresenter
+import mozilla.lockbox.support.isDebug
 
 @ExperimentalCoroutinesApi
 class RootActivity : AppCompatActivity() {
@@ -20,7 +21,7 @@ class RootActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_root)
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        if (!isDebug()) window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
 
         presenter.onViewReady()
     }

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -38,6 +38,7 @@ _all commits on all branches and pull requests are automatically built_
 4. push the tag to GitHub and create a corresponding "Release" on GitHub.com
   - copy the release notes to the "Release" on GitHub
   - download the `-signed.apk` from bitrise and attach it to the Release on GitHub
+  - **open the `-signed.apk` and confirm release build does not allow screenshots and does not expose the contents of the app in the switcher**
 5. Upload the `-signed.apk` (from bitrise) to the [Play Console][2]:
   - browse to "Release Management" > "App Releases" > "Internal test track" > "Manage"
   - "Create Release" and upload the signed APK, set the version to match the tag (for example: `1.2.1339`) then "Review" and the build will be immediately available to the core team
@@ -59,6 +60,7 @@ _similar to above, but requires explicit cherry-pick commits on `production` bra
   - copy the release notes to the "Release" on GitHub
 8. Browse to bitrise and find the desired `production` branch build to distribute
   - download the `.signed-apk` and attach it to the Release on GitHub
+  - **open the `-signed.apk` and confirm release build does not allow screenshots and does not expose the contents of the app in the switcher**
 9. Upload the `-signed.apk` (from bitrise) to the [Play Console][2]:
   - browse to "Release Management" > "App Releases" > "Internal test track" > "Manage"
   - "Create Release" and upload the signed APK, set the version to match the tag (for example: `1.2.1339`) then "Review" and the build will be immediately available to the core team


### PR DESCRIPTION
Fixes #368 

Is this too heavy of a carve-out making actual testing inconsistent with the expected behavior? Or light enough to be OK? Either way, I needed to do it today to actually take a screenshot... but that may be because I don't know a better way.

## Testing and Review Notes

_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_

- open simulator or a debug APK
- take a screenshot, it works ✅ 
- open a release APK
- take a screenshot, it "EOF" fails ❌ 

## Screenshots or Videos

I took a screenshot using simulator:

![device-2019-01-17-104044](https://user-images.githubusercontent.com/49511/51338676-b3059b00-1a47-11e9-9b25-e0cc9c82909b.png)