### PR TITLE
Add deeper link to FAQ anchor at top of page

### DIFF
--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -27,7 +27,7 @@ object Constant {
     }
 
     object Faq {
-        const val uri = "https://lockbox.firefox.com/faq.html"
+        const val uri = "https://lockbox.firefox.com/faq.html#top"
     }
 
     object SendFeedback {


### PR DESCRIPTION
Related to mozilla-lockbox/mozilla-lockbox.github.io#90