### PR TITLE
PSL-backed Hostname/Package matching

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
+    implementation 'com.google.guava:guava:27.0.1-android'
     implementation "com.jakewharton.rxbinding2:rxbinding:${rxbinding_version}"
     implementation "com.jakewharton.rxbinding2:rxbinding-design-kotlin:${rxbinding_version}"
     implementation "com.jakewharton.rxbinding2:rxbinding-appcompat-v7-kotlin:${rxbinding_version}"

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -72,13 +72,6 @@ class LockboxAutofillService(
             .addTo(compositeDisposable)
     }
 
-    private fun domainFromPackage(packageName: String): String? {
-        // naively assume that the `y` from `x.y.z`-style package name is the domain
-        // untested as we will change this implementation with issue #375
-        val domainRegex = Regex("^\\w+\\.(\\w+)\\..+")
-        return domainRegex.find(packageName)?.groupValues?.get(1)
-    }
-
     private fun buildFillResponse(
         possibleValues: List<ServerPassword>,
         parsedStructure: ParsedStructure

--- a/app/src/main/java/mozilla/lockbox/support/HostnameSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/HostnameSupport.kt
@@ -6,7 +6,6 @@
 
 package mozilla.lockbox.support
 
-import android.net.Uri
 import com.google.common.net.InternetDomainName
 import java.net.URI
 

--- a/app/src/main/java/mozilla/lockbox/support/HostnameSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/HostnameSupport.kt
@@ -8,6 +8,7 @@ package mozilla.lockbox.support
 
 import android.net.Uri
 import com.google.common.net.InternetDomainName
+import java.net.URI
 
 class HostnameSupport(idn: InternetDomainName?) {
     companion object {
@@ -25,7 +26,7 @@ class HostnameSupport(idn: InternetDomainName?) {
          * ("example.com").
          */
         fun fromUri(uriStr: String): HostnameSupport {
-            val domainName = Uri.parse(uriStr).host ?: ""
+            val domainName = URI.create(uriStr).host
             return fromDomainName(domainName)
         }
 
@@ -55,7 +56,7 @@ class HostnameSupport(idn: InternetDomainName?) {
     }
 
     fun matches(test: HostnameSupport): Boolean {
-        return this.topName == test.topName ||
-            this.topName.endsWith(".${test.topName}")
+        return test.fullName == this.topName ||
+            test.fullName.endsWith(".${this.topName}")
     }
 }

--- a/app/src/main/java/mozilla/lockbox/support/HostnameSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/HostnameSupport.kt
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.support
+
+import android.net.Uri
+import com.google.common.net.InternetDomainName
+
+class HostnameSupport(idn: InternetDomainName?) {
+    companion object {
+        /**
+         * Creates a `HostnameSupport` from the given Android/Java package name.
+         */
+        fun fromPackageName(pkgName: String): HostnameSupport {
+            val domainName = pkgName.split(".").asReversed().joinToString(".")
+            return fromDomainName(domainName)
+        }
+
+        /**
+         * Creates a `HostnameSupport` from the given URI.
+         * This parses the uri string ("https://example.com/login") to extract just the host portion
+         * ("example.com").
+         */
+        fun fromUri(uriStr: String): HostnameSupport {
+            val domainName = Uri.parse(uriStr).host ?: ""
+            return fromDomainName(domainName)
+        }
+
+        fun fromDomainName(domainName: String?): HostnameSupport {
+            val idn: InternetDomainName? = when (domainName) {
+                null, "" -> null
+                else -> InternetDomainName.from(domainName)
+            }
+            return HostnameSupport(idn)
+        }
+    }
+
+    val fullName: String = idn?.toString() ?: ""
+    val topName: String
+
+    init {
+        topName = when {
+            idn == null -> ""
+            !idn.isUnderPublicSuffix -> {
+                val parts = idn.parts()
+                val first = Math.max(parts.size - 2, 0)
+                val last = parts.size
+                parts.subList(first, last).joinToString(".")
+            }
+            else -> idn.topPrivateDomain().toString()
+        }
+    }
+
+    fun matches(test: HostnameSupport): Boolean {
+        return this.topName == test.topName ||
+            this.topName.endsWith(".${test.topName}")
+    }
+}

--- a/app/src/test/java/mozilla/lockbox/support/HostnameSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/HostnameSupportTest.kt
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.support
+
+import org.junit.Assert
+import org.junit.Test
+
+class HostnameSupportTest {
+    @Test
+    fun `converts a package name`() {
+        var support = HostnameSupport.fromPackageName("com.example.android")
+        Assert.assertEquals("android.example.com", support.fullName)
+        Assert.assertEquals("example.com", support.topName)
+
+        support = HostnameSupport.fromPackageName("uk.co.example.android")
+        Assert.assertEquals("android.example.co.uk", support.fullName)
+        Assert.assertEquals("example.co.uk", support.topName)
+
+        support = HostnameSupport.fromPackageName("com.blogspot.something.android")
+        Assert.assertEquals("android.something.blogspot.com", support.fullName)
+        Assert.assertEquals("something.blogspot.com", support.topName)
+
+        support = HostnameSupport.fromPackageName("example.example.android")
+        Assert.assertEquals("android.example.example", support.fullName)
+        Assert.assertEquals("example.example", support.topName)
+
+        support = HostnameSupport.fromPackageName("")
+        Assert.assertEquals("", support.fullName)
+        Assert.assertEquals("", support.topName)
+    }
+}

--- a/app/src/test/java/mozilla/lockbox/support/HostnameSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/HostnameSupportTest.kt
@@ -125,5 +125,9 @@ class HostnameSupportTest {
         formHost = HostnameSupport.fromDomainName("app.example.com.co")
         Assert.assertFalse(credHost.matches(formHost))
         Assert.assertFalse(formHost.matches(credHost))
+
+        formHost = HostnameSupport.fromDomainName("")
+        Assert.assertFalse(credHost.matches(formHost))
+        Assert.assertFalse(formHost.matches(credHost))
     }
 }

--- a/app/src/test/java/mozilla/lockbox/support/HostnameSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/HostnameSupportTest.kt
@@ -11,7 +11,77 @@ import org.junit.Test
 
 class HostnameSupportTest {
     @Test
-    fun `converts a package name`() {
+    fun `test creates from a domain name`() {
+        // tld + 1
+        var support = HostnameSupport.fromDomainName("example.com")
+        Assert.assertEquals("example.com", support.fullName)
+        Assert.assertEquals("example.com", support.topName)
+
+        // tld + 2
+        support = HostnameSupport.fromDomainName("www.example.com")
+        Assert.assertEquals("www.example.com", support.fullName)
+        Assert.assertEquals("example.com", support.topName)
+
+        // tld + 3
+        support = HostnameSupport.fromDomainName("us1.api.example.com")
+        Assert.assertEquals("us1.api.example.com", support.fullName)
+        Assert.assertEquals("example.com", support.topName)
+
+        // registry suffix
+        support = HostnameSupport.fromDomainName("www.example.co.uk")
+        Assert.assertEquals("www.example.co.uk", support.fullName)
+        Assert.assertEquals("example.co.uk", support.topName)
+
+        // public suffix
+        support = HostnameSupport.fromDomainName("www.something.blogspot.com")
+        Assert.assertEquals("www.something.blogspot.com", support.fullName)
+        Assert.assertEquals("something.blogspot.com", support.topName)
+
+        // non-existent suffix
+        support = HostnameSupport.fromDomainName("www.example.example")
+        Assert.assertEquals("www.example.example", support.fullName)
+        Assert.assertEquals("example.example", support.topName)
+
+        //
+
+        support = HostnameSupport.fromDomainName("")
+        Assert.assertEquals("", support.fullName)
+        Assert.assertEquals("", support.topName)
+    }
+
+    @Test
+    fun `test creates from a URI string`() {
+        var support = HostnameSupport.fromUri("https://example.com/")
+        Assert.assertEquals("example.com", support.fullName)
+        Assert.assertEquals("example.com", support.topName)
+
+        support = HostnameSupport.fromUri("https://example.com:8888/")
+        Assert.assertEquals("example.com", support.fullName)
+        Assert.assertEquals("example.com", support.topName)
+
+        support = HostnameSupport.fromUri("http://www.example.com/")
+        Assert.assertEquals("www.example.com", support.fullName)
+        Assert.assertEquals("example.com", support.topName)
+
+        support = HostnameSupport.fromUri("https://www.example.co.uk/")
+        Assert.assertEquals("www.example.co.uk", support.fullName)
+        Assert.assertEquals("example.co.uk", support.topName)
+
+        support = HostnameSupport.fromUri("https://www.something.blogspot.com/")
+        Assert.assertEquals("www.something.blogspot.com", support.fullName)
+        Assert.assertEquals("something.blogspot.com", support.topName)
+
+        support = HostnameSupport.fromUri("http://www.example.example/")
+        Assert.assertEquals("www.example.example", support.fullName)
+        Assert.assertEquals("example.example", support.topName)
+
+        support = HostnameSupport.fromUri("")
+        Assert.assertEquals("", support.fullName)
+        Assert.assertEquals("", support.topName)
+    }
+
+    @Test
+    fun `test creates from a package name`() {
         var support = HostnameSupport.fromPackageName("com.example.android")
         Assert.assertEquals("android.example.com", support.fullName)
         Assert.assertEquals("example.com", support.topName)
@@ -31,5 +101,29 @@ class HostnameSupportTest {
         support = HostnameSupport.fromPackageName("")
         Assert.assertEquals("", support.fullName)
         Assert.assertEquals("", support.topName)
+    }
+
+    @Test
+    fun testMatches() {
+        var credHost = HostnameSupport.fromDomainName("example.com")
+        var formHost = HostnameSupport.fromDomainName("example.com")
+        Assert.assertTrue(credHost.matches(formHost))
+        Assert.assertTrue(formHost.matches(credHost))
+
+        formHost = HostnameSupport.fromDomainName("www.example.com")
+        Assert.assertTrue(credHost.matches(formHost))
+        Assert.assertTrue(formHost.matches(credHost))
+
+        formHost = HostnameSupport.fromDomainName("en.android.example.com")
+        Assert.assertTrue(credHost.matches(formHost))
+        Assert.assertTrue(formHost.matches(credHost))
+
+        credHost = HostnameSupport.fromDomainName("app.example.com")
+        Assert.assertTrue(credHost.matches(formHost))
+        Assert.assertTrue(formHost.matches(credHost))
+
+        formHost = HostnameSupport.fromDomainName("app.example.com.co")
+        Assert.assertFalse(credHost.matches(formHost))
+        Assert.assertFalse(formHost.matches(credHost))
     }
 }


### PR DESCRIPTION
Improves hostname and package matching backed by the public suffix list, as implemented in Guava.

start on #375

## Testing and Review Notes

Largely in unit tests.

This tries to prevent filling credentials into phishing apps and websites.  Phishing apps can be hard to find, and we don't yet support WebView-based filling.


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)