### PR TITLE
Add launch icon to hint you can open the web address in browser

### DIFF
--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -85,6 +85,8 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputPassword.readOnly = true
         inputHostname.readOnly = true
         inputHostname.isClickable = true
+        inputHostname.isFocusable = true
+        btnHostnameLaunch.isClickable = false
 
         inputHostname.setText(item.hostname, TextView.BufferType.NORMAL)
         inputUsername.setText(item.username, TextView.BufferType.NORMAL)

--- a/app/src/main/res/drawable/ic_launch.xml
+++ b/app/src/main/res/drawable/ic_launch.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="18dp"
+        android:height="18dp"
+        android:viewportWidth="18"
+        android:viewportHeight="18">
+
+    <path
+            android:pathData="M5 1a1 1 0 1 1 0 2H4a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-1a1 1 0 0 1 2 0v1a3 3 0 0 1-3 3H4a3 3 0 0 1-3-3V4a3 3 0 0 1 3-3h1zm9.935.618a1 1 0 0 1 .077.382v5a1 1 0 0 1-2 0V4.414L9.72 7.707a1 1 0 1 1-1.414-1.414L11.598 3H9.012a1 1 0 1 1 0-2h5a1 1 0 0 1 .923.618z"
+            android:strokeWidth="1"
+            android:fillColor="#4A4A4F"
+            android:fillType="evenOdd"
+            android:strokeColor="#00000000"/>
+</vector>

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -42,6 +42,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:textColorHint="@color/black_60_percent"
+                    android:contentDescription="@string/launch_hostname_content_description"
                     app:layout_constraintTop_toTopOf="parent"
                     card_view:layout_constraintStart_toStartOf="parent"
                     card_view:layout_constraintEnd_toEndOf="parent">
@@ -60,6 +61,18 @@
                         tools:ignore="Autofill"/>
 
             </com.google.android.material.textfield.TextInputLayout>
+
+            <ImageView
+                    android:id="@+id/btnHostnameLaunch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:padding="8dp"
+                    android:background="@null"
+                    tools:ignore="ContentDescription"
+                    app:layout_constraintBottom_toBottomOf="@+id/inputLayoutHostname"
+                    app:layout_constraintRight_toRightOf="@+id/inputLayoutHostname"
+                    app:layout_constraintTop_toTopOf="@+id/inputLayoutHostname"
+                    app:srcCompat="@drawable/ic_launch"/>
 
             <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/inputLayoutUsername"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
     <!-- This message appears to link to a web page explaining how to make changes to the entry details -->
     <string name="learn_to_edit_entry">Learn how to edit this entry</string>
 
+    <!-- This describes an icon to screenreaders that the button tapped will open the web address in a web browser -->
+    <string name="launch_hostname_content_description">Open web address in web browser</string>
     <!-- This describes an icon to screenreaders that the button tapped will copy the username to the device clipboard to paste and use in another application -->
     <string name="copy_username_content_description">Copy your username</string>
     <!-- This message appears when the user taps to copy the username to the device clipboard -->


### PR DESCRIPTION
Closes #382

## Testing and Review Notes

1. open item detail view
2. tap to confirm the entire web address row is 'clickable' including the new button
3. (accessibility) confirm the voice over instructions explain the web address opens in browser (and no separate selection of the icon indicator)

## Screenshots or Videos


![android_emulator_-_pixel_2_api_28_5554](https://user-images.githubusercontent.com/49511/51636033-6f160880-1f15-11e9-8f68-73104bbf1004.png)

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] ~add unit tests~
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
