### PR TITLE
enable autofill from settings page

### DIFF
--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -103,7 +103,7 @@ open class LockboxApplication : Application() {
 
     private fun leakCanary(): Boolean {
         // disable LeakCanary when unitTesting
-        if (unitTesting) return false
+        if (isUnitTest()) return false
         else if (LeakCanary.isInAnalyzerProcess(this)) {
             // This process is dedicated to LeakCanary for heap analysis.
             // You should not init your app in this process.

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -6,6 +6,8 @@
 
 package mozilla.lockbox.action
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import mozilla.lockbox.R
 import mozilla.lockbox.flux.Action
@@ -63,5 +65,7 @@ sealed class RouteAction(
 }
 
 enum class SettingIntent(val intentAction: String) {
-    Security(android.provider.Settings.ACTION_SECURITY_SETTINGS)
+    Security(android.provider.Settings.ACTION_SECURITY_SETTINGS),
+    @RequiresApi(Build.VERSION_CODES.O)
+    Autofill(android.provider.Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)
 }

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -6,6 +6,7 @@
 
 package mozilla.lockbox.action
 
+import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
@@ -64,8 +65,8 @@ sealed class RouteAction(
     }
 }
 
-enum class SettingIntent(val intentAction: String) {
+enum class SettingIntent(val intentAction: String, val data: Uri? = null) {
     Security(android.provider.Settings.ACTION_SECURITY_SETTINGS),
     @RequiresApi(Build.VERSION_CODES.O)
-    Autofill(android.provider.Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE)
+    Autofill(android.provider.Settings.ACTION_REQUEST_SET_AUTOFILL_SERVICE, Uri.parse("package:com.mozilla.lockbox"))
 }

--- a/app/src/main/java/mozilla/lockbox/action/SettingAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/SettingAction.kt
@@ -20,6 +20,7 @@ open class SettingAction(
     data class SendUsageData(val sendUsageData: Boolean) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_record_usage_data, null)
     data class ItemListSortOrder(val sortOrder: Setting.ItemListSort) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_item_list_order, null)
     data class AutoLockTime(val time: Setting.AutoLockTime) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_autolock_time, time.seconds.toString())
+    data class Autofill(val enable: Boolean) : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_autofill, null)
     object Reset : SettingAction(TelemetryEventMethod.setting_changed, TelemetryEventObject.settings_reset, null)
 }
 

--- a/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/TelemetryAction.kt
@@ -74,6 +74,7 @@ enum class TelemetryEventObject {
     settings_fingerprint,
     settings_fingerprint_pending_auth,
     settings_item_list_order,
+    settings_autofill,
     login_welcome,
     login_fxa,
     login_onboarding_confirmation,

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -280,6 +280,7 @@ class RoutePresenter(
 
     private fun openSetting(settingAction: RouteAction.SystemSetting) {
         val settingIntent = Intent(settingAction.setting.intentAction)
+        settingIntent.data = settingAction.setting.data
         activity.startActivity(settingIntent, null)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
@@ -6,6 +6,9 @@
 
 package mozilla.lockbox.presenter
 
+import android.os.Build
+import androidx.annotation.RequiresApi
+import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.Observables
 import io.reactivex.rxkotlin.addTo
@@ -14,6 +17,7 @@ import mozilla.lockbox.R
 import mozilla.lockbox.action.FingerprintAuthAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.SettingAction
+import mozilla.lockbox.action.SettingIntent
 import mozilla.lockbox.adapter.AppVersionSettingConfiguration
 import mozilla.lockbox.adapter.SectionedAdapter
 import mozilla.lockbox.adapter.SettingCellConfiguration
@@ -62,7 +66,10 @@ class SettingPresenter(
         }
 
     private val autoFillObserver: Consumer<Boolean>
-        get() = Consumer { }
+        @RequiresApi(Build.VERSION_CODES.O)
+        get() = Consumer {
+            dispatcher.dispatch(RouteAction.SystemSetting(SettingIntent.Autofill))
+        }
 
     private val sendUsageDataObserver: Consumer<Boolean>
         get() = Consumer { newValue ->
@@ -95,22 +102,40 @@ class SettingPresenter(
     }
 
     private fun updateSettings() {
-        var settings = listOf(
+        var configurationSettings: List<SettingCellConfiguration> = listOf(
             TextSettingConfiguration(
                 title = R.string.auto_lock,
                 contentDescription = R.string.auto_lock_description,
                 detailTextDriver = settingStore.autoLockTime.map { it.stringValue },
                 clickListener = autoLockTimeClickListener
-            ),
-            /* TODO: enable Autofill setting and increase supportIndex once it's actually implemented
-            ToggleSettingConfiguration(
+            ))
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && settingStore.autofillAvailable) {
+            configurationSettings += ToggleSettingConfiguration(
                 title = R.string.autofill,
                 subtitle = R.string.autofill_summary,
                 contentDescription = R.string.autofill_description,
-                toggleDriver = Observable.just(true),
+                toggleDriver = Observable.just(settingStore.isCurrentAutofillProvider),
                 toggleObserver = autoFillObserver
-            ),
-            */
+            )
+        }
+
+        if (fingerprintStore.isFingerprintAuthAvailable) {
+            configurationSettings = listOf(
+                ToggleSettingConfiguration(
+                    title = R.string.unlock,
+                    contentDescription = R.string.fingerprint_description,
+                    toggleDriver = Observables.combineLatest(
+                        settingStore.unlockWithFingerprintPendingAuth,
+                        settingStore.unlockWithFingerprint
+                    )
+                        .map { unlock -> unlock.first.takeIf { it } ?: unlock.second },
+                    toggleObserver = enableFingerprintObserver
+                )
+            ) + configurationSettings
+        }
+
+        val supportSettings = listOf(
             ToggleSettingConfiguration(
                 title = R.string.send_usage_data,
                 subtitle = R.string.send_usage_data_summary,
@@ -125,30 +150,11 @@ class SettingPresenter(
             )
         )
 
-        var supportIndex = 1
-
-        if (fingerprintStore.isFingerprintAuthAvailable) {
-            settings = listOf(
-                ToggleSettingConfiguration(
-                    title = R.string.unlock,
-                    contentDescription = R.string.fingerprint_description,
-                    toggleDriver = Observables.combineLatest(
-                        settingStore.unlockWithFingerprintPendingAuth,
-                        settingStore.unlockWithFingerprint
-                    )
-                        .map { unlock -> unlock.first.takeIf { it } ?: unlock.second },
-                    toggleObserver = enableFingerprintObserver
-                )
-            ) + settings
-
-            supportIndex += 1
-        }
-
         val sections = listOf(
             SectionedAdapter.Section(0, R.string.configuration_title),
-            SectionedAdapter.Section(supportIndex, R.string.support_title)
+            SectionedAdapter.Section(configurationSettings.size, R.string.support_title)
         )
 
-        view.updateSettingList(settings, sections)
+        view.updateSettingList(configurationSettings + supportSettings, sections)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
@@ -67,8 +67,12 @@ class SettingPresenter(
 
     private val autoFillObserver: Consumer<Boolean>
         @RequiresApi(Build.VERSION_CODES.O)
-        get() = Consumer {
-            dispatcher.dispatch(RouteAction.SystemSetting(SettingIntent.Autofill))
+        get() = Consumer { newValue ->
+            dispatcher.dispatch(SettingAction.Autofill(newValue))
+
+            if (newValue) {
+                dispatcher.dispatch(RouteAction.SystemSetting(SettingIntent.Autofill))
+            }
         }
 
     private val sendUsageDataObserver: Consumer<Boolean>

--- a/app/src/main/java/mozilla/lockbox/store/SettingStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/SettingStore.kt
@@ -87,6 +87,8 @@ open class SettingStore(
                         edit.putString(Keys.AUTO_LOCK_TIME, it.time.name)
                     is SettingAction.UnlockWithFingerprintPendingAuth ->
                         edit.putBoolean(Keys.UNLOCK_WITH_FINGERPRINT_PENDING_AUTH, it.unlockWithFingerprintPendingAuth)
+                    is SettingAction.Autofill ->
+                        handleAutofill(it.enable)
                     is SettingAction.Reset -> {
                         edit.putBoolean(Keys.SEND_USAGE_DATA, Constant.SettingDefault.sendUsageData)
                         edit.putString(Keys.ITEM_LIST_SORT_ORDER, Constant.SettingDefault.itemListSort.name)
@@ -134,6 +136,12 @@ open class SettingStore(
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             autofillManager = context.getSystemService(AutofillManager::class.java)
+        }
+    }
+
+    private fun handleAutofill(enable: Boolean) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !enable) {
+            autofillManager.disableAutofillServices()
         }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/SettingStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/SettingStore.kt
@@ -56,6 +56,7 @@ open class SettingStore(
         dispatcher.register
             .filterByType(FingerprintAuthAction::class.java)
 
+    // Accessing these properties in an environment with an Android SDK lower than V26 will result in app crashes!
     open val autofillAvailable: Boolean
         @RequiresApi(Build.VERSION_CODES.O)
         get() = autofillManager.isAutofillSupported

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,4 +210,7 @@
     <string name="no_entries_description">Firefox Lockbox lets you access passwords you\'ve already saved to Firefox. To
         view your entries here, you\'ll need to sign in and sync in Firefox.
     </string>
+    <string name="autofill">Autofill</string>
+    <string name="autofill_description">Autofill Setting</string>
+    <string name="autofill_summary">Let Firefox Lockbox fill in logins for you</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,11 +123,11 @@
     <string name="never">Never</string>
 
     <!-- This is the title of a setting that allows the user to automatically fill forms in Android applications and websites using username and password data from this application -->
-    <!-- <string name="autofill">Autofill</string> -->
+     <string name="autofill">Autofill</string>
     <!-- This is the sub-title of a setting that allows the user to automatically fill forms in Android applications and websites using username and password data from this application, not expected to translate Firefox Lockbox -->
-    <!-- <string name="autofill_summary">Let Firefox Lockbox fill in logins for you</string> -->
+     <string name="autofill_summary">Let Firefox Lockbox fill in logins for you</string>
     <!-- This is the label a screenreader uses to inform the user they selected the autofill setting toggle -->
-    <!-- <string name="autofill_description">Application autofill setting</string> -->
+     <string name="autofill_description">Application autofill setting</string>
 
     <!-- This is the title of a setting that allows the user to enable and disable the sending of telemetry usage data to Mozilla -->
     <string name="send_usage_data">Send usage data</string>
@@ -210,7 +210,4 @@
     <string name="no_entries_description">Firefox Lockbox lets you access passwords you\'ve already saved to Firefox. To
         view your entries here, you\'ll need to sign in and sync in Firefox.
     </string>
-    <string name="autofill">Autofill</string>
-    <string name="autofill_description">Autofill Setting</string>
-    <string name="autofill_summary">Let Firefox Lockbox fill in logins for you</string>
 </resources>

--- a/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
@@ -56,24 +56,27 @@ class ListAdapterTestHelper {
         )
     }
 
-    fun createAccurateListOfSettings(isFingerprintAvailable: Boolean): List<SettingCellConfiguration> {
-        var settings = listOf(
+    fun createAccurateListOfSettings(isFingerprintAvailable: Boolean, isAutofillAvailable: Boolean): List<SettingCellConfiguration> {
+        var settings: List<SettingCellConfiguration> = listOf(
             TextSettingConfiguration(
                 title = R.string.auto_lock,
-                contentDescription = R.string.empty_string,
+                contentDescription = R.string.auto_lock_description,
                 detailTextDriver = textDriverFake,
                 clickListener = textClicksConsumerFake
-            ),
-            /* TODO: enable Autofill setting once it's actually implemented
-            ToggleSettingConfiguration(
+            )
+        )
+
+        if (isAutofillAvailable) {
+            settings += ToggleSettingConfiguration(
                 title = R.string.autofill,
                 subtitle = R.string.autofill_summary,
                 contentDescription = R.string.empty_string,
                 toggleDriver = toggleDriverFake,
                 toggleObserver = toggleConsumerFake
-            ),
-            */
-            ToggleSettingConfiguration(
+            )
+        }
+
+        settings += listOf(ToggleSettingConfiguration(
                 title = R.string.send_usage_data,
                 subtitle = R.string.send_usage_data_summary,
                 contentDescription = R.string.empty_string,
@@ -86,6 +89,7 @@ class ListAdapterTestHelper {
                 contentDescription = R.string.empty_string
             )
         )
+
         if (isFingerprintAvailable) {
             settings = listOf(
                 ToggleSettingConfiguration(
@@ -96,6 +100,7 @@ class ListAdapterTestHelper {
                 )
             ) + settings
         }
+
         return settings
     }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
@@ -15,6 +15,7 @@ import mozilla.lockbox.action.FingerprintAuthAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.action.SettingAction
+import mozilla.lockbox.action.SettingIntent
 import mozilla.lockbox.adapter.ListAdapterTestHelper
 import mozilla.lockbox.adapter.SectionedAdapter
 import mozilla.lockbox.adapter.SettingCellConfiguration
@@ -60,6 +61,13 @@ class SettingPresenterTest {
         override var autoLockTime: Observable<Setting.AutoLockTime> = PublishSubject.create<Setting.AutoLockTime>()
 
         override val onEnablingFingerprint: Observable<FingerprintAuthAction> = PublishSubject.create()
+
+        var autofillAvailableStub: Boolean = false
+        override val autofillAvailable: Boolean
+            get() = autofillAvailableStub
+
+        override val isCurrentAutofillProvider: Boolean
+            get() = false
     }
 
     private lateinit var testHelper: ListAdapterTestHelper
@@ -84,9 +92,59 @@ class SettingPresenterTest {
     }
 
     @Test
-    fun `update settings when fingerprint available`() {
+    fun `update settings when fingerprint available and autofill unavailable`() {
         whenCalled(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
-        val expectedSettings = testHelper.createAccurateListOfSettings(true)
+        settingStore.autofillAvailableStub = false
+        val expectedSettings = testHelper.createAccurateListOfSettings(true, false)
+
+        val expectedSections = listOf(
+            SectionedAdapter.Section(0, R.string.configuration_title),
+            SectionedAdapter.Section(2, R.string.support_title)
+        )
+
+        subject.onResume()
+
+        assertEquals(view.settingItem!![0].title, expectedSettings[0].title)
+        assertEquals(view.settingItem!![1].title, expectedSettings[1].title)
+        assertEquals(view.settingItem!![2].title, expectedSettings[2].title)
+        assertEquals(view.settingItem!![3].title, expectedSettings[3].title)
+
+        assertEquals(view.sectionsItem!![0].title, expectedSections[0].title)
+        assertEquals(view.sectionsItem!![1].title, expectedSections[1].title)
+
+        assertEquals(view.sectionsItem!![0].firstPosition, expectedSections[0].firstPosition)
+        assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
+    }
+
+    @Test
+    fun `update settings when fingerprint unavailable and autofill unavailable`() {
+        whenCalled(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
+        settingStore.autofillAvailableStub = false
+        val expectedSettings = testHelper.createAccurateListOfSettings(false, false)
+
+        val expectedSections = listOf(
+            SectionedAdapter.Section(0, R.string.configuration_title),
+            SectionedAdapter.Section(1, R.string.support_title)
+        )
+
+        subject.onResume()
+
+        assertEquals(view.settingItem!![0].title, expectedSettings[0].title)
+        assertEquals(view.settingItem!![1].title, expectedSettings[1].title)
+        assertEquals(view.settingItem!![2].title, expectedSettings[2].title)
+
+        assertEquals(view.sectionsItem!![0].title, expectedSections[0].title)
+        assertEquals(view.sectionsItem!![1].title, expectedSections[1].title)
+
+        assertEquals(view.sectionsItem!![0].firstPosition, expectedSections[0].firstPosition)
+        assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
+    }
+
+    @Test
+    fun `update settings when fingerprint available and autofill available`() {
+        whenCalled(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
+        settingStore.autofillAvailableStub = true
+        val expectedSettings = testHelper.createAccurateListOfSettings(true, true)
 
         val expectedSections = listOf(
             SectionedAdapter.Section(0, R.string.configuration_title),
@@ -99,19 +157,19 @@ class SettingPresenterTest {
         assertEquals(view.settingItem!![1].title, expectedSettings[1].title)
         assertEquals(view.settingItem!![2].title, expectedSettings[2].title)
         assertEquals(view.settingItem!![3].title, expectedSettings[3].title)
-        // assertEquals(view.settingItem!![4].title, expectedSettings[4].title)
 
         assertEquals(view.sectionsItem!![0].title, expectedSections[0].title)
         assertEquals(view.sectionsItem!![1].title, expectedSections[1].title)
 
         assertEquals(view.sectionsItem!![0].firstPosition, expectedSections[0].firstPosition)
-        // assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
+        assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
     }
 
     @Test
-    fun `update settings when fingerprint unavailable`() {
+    fun `update settings when fingerprint unavailable and autofill available`() {
         whenCalled(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
-        val expectedSettings = testHelper.createAccurateListOfSettings(false)
+        settingStore.autofillAvailableStub = true
+        val expectedSettings = testHelper.createAccurateListOfSettings(false, true)
 
         val expectedSections = listOf(
             SectionedAdapter.Section(0, R.string.configuration_title),
@@ -123,13 +181,13 @@ class SettingPresenterTest {
         assertEquals(view.settingItem!![0].title, expectedSettings[0].title)
         assertEquals(view.settingItem!![1].title, expectedSettings[1].title)
         assertEquals(view.settingItem!![2].title, expectedSettings[2].title)
-        // assertEquals(view.settingItem!![3].title, expectedSettings[3].title)
+        assertEquals(view.settingItem!![3].title, expectedSettings[3].title)
 
         assertEquals(view.sectionsItem!![0].title, expectedSections[0].title)
         assertEquals(view.sectionsItem!![1].title, expectedSections[1].title)
 
         assertEquals(view.sectionsItem!![0].firstPosition, expectedSections[0].firstPosition)
-        // assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
+        assertEquals(view.sectionsItem!![1].firstPosition, expectedSections[1].firstPosition)
     }
 
     @Test
@@ -229,5 +287,16 @@ class SettingPresenterTest {
         (view.settingItem!![0] as TextSettingConfiguration).clickListener.accept(Unit)
 
         dispatcherObserver.assertLastValue(RouteAction.AutoLockSetting)
+    }
+
+    @Test
+    fun `autofill provider update requested`() {
+        Mockito.`when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
+        settingStore.autofillAvailableStub = true
+        subject.onResume()
+
+        (view.settingItem!![1] as ToggleSettingConfiguration).toggleObserver.accept(true)
+
+        dispatcherObserver.assertLastValue(RouteAction.SystemSetting(SettingIntent.Autofill))
     }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
@@ -290,7 +290,7 @@ class SettingPresenterTest {
     }
 
     @Test
-    fun `autofill provider update requested`() {
+    fun `autofill provider enabled`() {
         Mockito.`when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
         settingStore.autofillAvailableStub = true
         subject.onResume()
@@ -298,5 +298,16 @@ class SettingPresenterTest {
         (view.settingItem!![1] as ToggleSettingConfiguration).toggleObserver.accept(true)
 
         dispatcherObserver.assertLastValue(RouteAction.SystemSetting(SettingIntent.Autofill))
+    }
+
+    @Test
+    fun `autofill provider disabled`() {
+        Mockito.`when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
+        settingStore.autofillAvailableStub = true
+        subject.onResume()
+
+        (view.settingItem!![1] as ToggleSettingConfiguration).toggleObserver.accept(false)
+
+        dispatcherObserver.assertLastValue(SettingAction.Autofill(false))
     }
 }


### PR DESCRIPTION
Fixes #56

## Testing and Review Notes

Currently, disabling the setting will remove Lockbox as a credential provider and not take the user to the settings page. There's no credential provider interaction when the user resets their account or settings right now pending a product decision.

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
