### PR TITLE
Update lint baseline for navigation 1.0.0-beta01

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -3,7 +3,7 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of android.arch.navigation:navigation-fragment than 1.0.0-alpha09 is available: 1.0.0-alpha11"
+        message="A newer version of android.arch.navigation:navigation-fragment than 1.0.0-alpha11 is available: 1.0.0-beta01"
         errorLine1="    implementation &quot;android.arch.navigation:navigation-fragment:$navigation_version&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -14,7 +14,7 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of android.arch.navigation:navigation-ui-ktx than 1.0.0-alpha09 is available: 1.0.0-alpha11"
+        message="A newer version of android.arch.navigation:navigation-ui-ktx than 1.0.0-alpha11 is available: 1.0.0-beta01"
         errorLine1="    implementation &quot;android.arch.navigation:navigation-ui-ktx:$navigation_version&quot;"
         errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location


### PR DESCRIPTION
Not planning to update to navigation 1.0.0-beta01 right now, captured at #401

Merging once green to get master and branches/PRs back to passing lint checks...
