### PR TITLE
Add FAQ links

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -85,6 +85,11 @@ sealed class RouteAction(
             R.string.nav_menu_faq,
             TelemetryEventObject.settings_faq)
 
+        object Privacy : AppWebPage(
+            Constant.Privacy.uri,
+            R.string.privacy,
+            TelemetryEventObject.settings_faq)
+
         object SendFeedback : AppWebPage(
             Constant.SendFeedback.uri,
             R.string.nav_menu_feedback,

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -56,7 +56,32 @@ sealed class RouteAction(
     ) : RouteAction(TelemetryEventMethod.show, eventObject) {
 
         object FaqList : AppWebPage(
-            Constant.Faq.uri,
+            Constant.Faq.topUri,
+            R.string.nav_menu_faq,
+            TelemetryEventObject.settings_faq)
+
+        object FaqWelcome : AppWebPage(
+            Constant.Faq.savedUri,
+            R.string.nav_menu_faq,
+            TelemetryEventObject.settings_faq)
+
+        object FaqSecurity : AppWebPage(
+            Constant.Faq.securityUri,
+            R.string.nav_menu_faq,
+            TelemetryEventObject.settings_faq)
+
+        object FaqSync : AppWebPage(
+            Constant.Faq.syncUri,
+            R.string.nav_menu_faq,
+            TelemetryEventObject.settings_faq)
+
+        object FaqCreate : AppWebPage(
+            Constant.Faq.createUri,
+            R.string.nav_menu_faq,
+            TelemetryEventObject.settings_faq)
+
+        object FaqEdit : AppWebPage(
+            Constant.Faq.editUri,
             R.string.nav_menu_faq,
             TelemetryEventObject.settings_faq)
 

--- a/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
@@ -47,7 +47,7 @@ class ItemListAdapter : RecyclerView.Adapter<ItemListCell>() {
 
                 view.noMatchingLearnMore
                     .clicks()
-                    .subscribe(noMatchingEntriesClicks as PublishSubject)
+                    .subscribe(noMatchingEntriesClicks as Subject)
 
                 return ItemListCell(view)
             }

--- a/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/ItemListAdapter.kt
@@ -6,19 +6,21 @@
 
 package mozilla.lockbox.adapter
 
-import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
 import com.jakewharton.rxbinding2.view.clicks
-import com.jakewharton.rxbinding2.view.detaches
 import io.reactivex.Observable
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.rxkotlin.addTo
 import io.reactivex.subjects.PublishSubject
+import io.reactivex.subjects.Subject
 import kotlinx.android.extensions.LayoutContainer
+import kotlinx.android.synthetic.main.list_cell_no_entries.view.*
+import kotlinx.android.synthetic.main.list_cell_no_matching.view.*
 import mozilla.lockbox.R
+import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.model.ItemViewModel
+import mozilla.lockbox.support.asOptional
 import mozilla.lockbox.view.ItemViewHolder
 
 open class ItemListCell(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer
@@ -26,9 +28,10 @@ open class ItemListCell(override val containerView: View) : RecyclerView.ViewHol
 class ItemListAdapter : RecyclerView.Adapter<ItemListCell>() {
 
     private var itemList: List<ItemViewModel>? = null
-    private val _clicks = PublishSubject.create<ItemViewModel>()
-    private val compositeDisposable = CompositeDisposable()
     private var isFiltering: Boolean = false
+    val itemClicks: Observable<ItemViewModel> = PublishSubject.create()
+    val noEntriesClicks: Observable<Unit> = PublishSubject.create()
+    val noMatchingEntriesClicks: Observable<Unit> = PublishSubject.create()
 
     companion object {
         private const val ITEM_DISPLAY_CELL_TYPE = 0
@@ -42,21 +45,30 @@ class ItemListAdapter : RecyclerView.Adapter<ItemListCell>() {
             NO_MATCHING_ENTRIES_CELL_TYPE -> {
                 val view = inflater.inflate(R.layout.list_cell_no_matching, parent, false)
 
+                view.noMatchingLearnMore
+                    .clicks()
+                    .subscribe(noMatchingEntriesClicks as PublishSubject)
+
                 return ItemListCell(view)
             }
-            NO_ENTRIES_CELL_TYPE ->
-                return ItemListCell(inflater.inflate(R.layout.list_cell_no_entries, parent, false))
+            NO_ENTRIES_CELL_TYPE -> {
+                val view = inflater.inflate(R.layout.list_cell_no_entries, parent, false)
+
+                view.noEntriesLearnMore
+                    .clicks()
+                    .subscribe(noEntriesClicks as Subject)
+
+                return ItemListCell(view)
+            }
             else -> {
                 val view = inflater.inflate(R.layout.list_cell_item, parent, false)
 
                 val viewHolder = ItemViewHolder(view)
-                view
-                    .clicks()
-                    .takeUntil(parent.detaches())
-                    .subscribe {
-                        viewHolder.itemViewModel?.let(this._clicks::onNext)
-                    }
-                    .addTo(compositeDisposable)
+
+                view.clicks()
+                    .map { viewHolder.itemViewModel.asOptional() }
+                    .filterNotNull()
+                    .subscribe(this.itemClicks as Subject)
 
                 return viewHolder
             }
@@ -92,9 +104,5 @@ class ItemListAdapter : RecyclerView.Adapter<ItemListCell>() {
         // note: this is not a performant way to do updates; we should think about using
         // diffutil here when implementing filtering / sorting
         notifyDataSetChanged()
-    }
-
-    fun clicks(): Observable<ItemViewModel> {
-        return this._clicks
     }
 }

--- a/app/src/main/java/mozilla/lockbox/adapter/SettingCellConfiguration.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SettingCellConfiguration.kt
@@ -29,6 +29,7 @@ class ToggleSettingConfiguration(
     override val subtitle: Int? = null,
     @StringRes override val contentDescription: Int,
     @StringRes val buttonTitle: Int? = null,
+    val buttonObserver: Consumer<Unit>? = null,
     val toggleDriver: Observable<Boolean>,
     val toggleObserver: Consumer<Boolean>
 ) : SettingCellConfiguration(title = title, contentDescription = contentDescription)

--- a/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
@@ -75,6 +75,9 @@ class SettingListAdapter : RecyclerView.Adapter<SettingViewHolder>() {
                 holder.subtitle = configuration.subtitle ?: R.string.empty_string
                 holder.buttonTitle = configuration.buttonTitle ?: R.string.empty_string
                 holder.contentDescription = configuration.contentDescription
+                holder.buttonClicks
+                    .subscribe(configuration.buttonObserver)
+                    .addTo(compositeDisposable)
                 configuration.toggleDriver
                     .subscribe {
                         holder.toggle.isChecked = it

--- a/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
+++ b/app/src/main/java/mozilla/lockbox/adapter/SettingListAdapter.kt
@@ -75,9 +75,11 @@ class SettingListAdapter : RecyclerView.Adapter<SettingViewHolder>() {
                 holder.subtitle = configuration.subtitle ?: R.string.empty_string
                 holder.buttonTitle = configuration.buttonTitle ?: R.string.empty_string
                 holder.contentDescription = configuration.contentDescription
-                holder.buttonClicks
-                    .subscribe(configuration.buttonObserver)
-                    .addTo(compositeDisposable)
+                configuration.buttonObserver?.let {
+                    holder.buttonClicks
+                        .subscribe(it)
+                        .addTo(compositeDisposable)
+                }
                 configuration.toggleDriver
                     .subscribe {
                         holder.toggle.isChecked = it

--- a/app/src/main/java/mozilla/lockbox/presenter/FilterPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FilterPresenter.kt
@@ -25,6 +25,7 @@ interface FilterView {
     val cancelButtonClicks: Observable<Unit>
     val cancelButtonVisibility: Consumer<in Boolean>
     val itemSelection: Observable<ItemViewModel>
+    val noMatchingClicks: Observable<Unit>
     fun updateItems(items: List<ItemViewModel>)
 }
 
@@ -43,6 +44,11 @@ class FilterPresenter(
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(view::updateItems)
                 .addTo(compositeDisposable)
+
+        view.noMatchingClicks
+            .map { RouteAction.AppWebPage.FaqCreate }
+            .subscribe(dispatcher::dispatch)
+            .addTo(compositeDisposable)
 
         view.filterTextEntered
                 .map { it.isNotEmpty() }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -77,7 +77,7 @@ class ItemDetailPresenter(
         this.view.learnMoreClicks
             .subscribe {
                 // TODO: fix "Cannot route from mozilla.lockbox:id/fragment_item_detail to mozilla.lockbox:id/fragment_webview"
-                dispatcher.dispatch(RouteAction.AppWebPage.FaqList)
+                dispatcher.dispatch(RouteAction.AppWebPage.FaqEdit)
             }
             .addTo(compositeDisposable)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -75,10 +75,8 @@ class ItemDetailPresenter(
         }
 
         this.view.learnMoreClicks
-            .subscribe {
-                // TODO: fix "Cannot route from mozilla.lockbox:id/fragment_item_detail to mozilla.lockbox:id/fragment_webview"
-                dispatcher.dispatch(RouteAction.AppWebPage.FaqEdit)
-            }
+            .map { RouteAction.AppWebPage.FaqEdit }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
         this.view.togglePasswordClicks

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -30,6 +30,7 @@ interface ItemDetailView {
     val passwordCopyClicks: Observable<Unit>
     val togglePasswordClicks: Observable<Unit>
     val hostnameClicks: Observable<Unit>
+    val learnMoreClicks: Observable<Unit>
     var isPasswordVisible: Boolean
     fun updateItem(item: ItemDetailViewModel)
     fun showToastNotification(@StringRes strId: Int)
@@ -72,6 +73,13 @@ class ItemDetailPresenter(
                 dispatcher.dispatch(RouteAction.OpenWebsite(it.hostname))
             }
         }
+
+        this.view.learnMoreClicks
+            .subscribe {
+                // TODO: fix "Cannot route from mozilla.lockbox:id/fragment_item_detail to mozilla.lockbox:id/fragment_webview"
+                dispatcher.dispatch(RouteAction.AppWebPage.FaqList)
+            }
+            .addTo(compositeDisposable)
 
         this.view.togglePasswordClicks
             .subscribe {

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -36,6 +36,7 @@ interface ItemListView {
     val itemSelection: Observable<ItemViewModel>
     val filterClicks: Observable<Unit>
     val noEntriesClicks: Observable<Unit>
+    val noMatchingClicks: Observable<Unit>
     val menuItemSelections: Observable<Int>
     val lockNowClick: Observable<Unit>
     val sortItemSelection: Observable<Setting.ItemListSort>
@@ -112,6 +113,12 @@ class ItemListPresenter(
             .addTo(compositeDisposable)
 
         view.noEntriesClicks
+            .subscribe {
+                dispatcher.dispatch(RouteAction.AppWebPage.FaqList)
+            }
+            .addTo(compositeDisposable)
+
+        view.noMatchingClicks
             .subscribe {
                 dispatcher.dispatch(RouteAction.AppWebPage.FaqList)
             }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -114,13 +114,13 @@ class ItemListPresenter(
 
         view.noEntriesClicks
             .subscribe {
-                dispatcher.dispatch(RouteAction.AppWebPage.FaqList)
+                dispatcher.dispatch(RouteAction.AppWebPage.FaqSync)
             }
             .addTo(compositeDisposable)
 
         view.noMatchingClicks
             .subscribe {
-                dispatcher.dispatch(RouteAction.AppWebPage.FaqList)
+                dispatcher.dispatch(RouteAction.AppWebPage.FaqCreate)
             }
             .addTo(compositeDisposable)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -36,7 +36,6 @@ interface ItemListView {
     val itemSelection: Observable<ItemViewModel>
     val filterClicks: Observable<Unit>
     val noEntriesClicks: Observable<Unit>
-    val noMatchingClicks: Observable<Unit>
     val menuItemSelections: Observable<Int>
     val lockNowClick: Observable<Unit>
     val sortItemSelection: Observable<Setting.ItemListSort>
@@ -112,11 +111,6 @@ class ItemListPresenter(
 
         view.noEntriesClicks
             .map { RouteAction.AppWebPage.FaqSync }
-            .subscribe(dispatcher::dispatch)
-            .addTo(compositeDisposable)
-
-        view.noMatchingClicks
-            .map { RouteAction.AppWebPage.FaqCreate }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -101,27 +101,23 @@ class ItemListPresenter(
             .addTo(compositeDisposable)
 
         view.itemSelection
-            .subscribe { it ->
-                dispatcher.dispatch(RouteAction.ItemDetail(it.guid))
-            }
+            .map { RouteAction.ItemDetail(it.guid) }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
         view.filterClicks
-            .subscribe {
-                dispatcher.dispatch(RouteAction.Filter)
-            }
+            .map { RouteAction.Filter }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
         view.noEntriesClicks
-            .subscribe {
-                dispatcher.dispatch(RouteAction.AppWebPage.FaqSync)
-            }
+            .map { RouteAction.AppWebPage.FaqSync }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
         view.noMatchingClicks
-            .subscribe {
-                dispatcher.dispatch(RouteAction.AppWebPage.FaqCreate)
-            }
+            .map { RouteAction.AppWebPage.FaqCreate }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
 
         view.menuItemSelections
@@ -138,9 +134,11 @@ class ItemListPresenter(
             .addTo(compositeDisposable)
 
         view.sortItemSelection
-            .subscribe { sortBy ->
-                dispatcher.dispatch(SettingAction.ItemListSortOrder(sortBy))
-            }.addTo(compositeDisposable)
+            .map { sortBy ->
+                SettingAction.ItemListSortOrder(sortBy)
+            }
+            .subscribe(dispatcher::dispatch)
+            .addTo(compositeDisposable)
 
         view.refreshItemList
             .doOnDispose { view.stopRefreshing() }

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -35,6 +35,7 @@ import mozilla.lockbox.store.SettingStore
 interface ItemListView {
     val itemSelection: Observable<ItemViewModel>
     val filterClicks: Observable<Unit>
+    val noEntriesClicks: Observable<Unit>
     val menuItemSelections: Observable<Int>
     val lockNowClick: Observable<Unit>
     val sortItemSelection: Observable<Setting.ItemListSort>
@@ -107,6 +108,12 @@ class ItemListPresenter(
         view.filterClicks
             .subscribe {
                 dispatcher.dispatch(RouteAction.Filter)
+            }
+            .addTo(compositeDisposable)
+
+        view.noEntriesClicks
+            .subscribe {
+                dispatcher.dispatch(RouteAction.AppWebPage.FaqList)
             }
             .addTo(compositeDisposable)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/OnboardingConfirmationPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/OnboardingConfirmationPresenter.kt
@@ -9,11 +9,13 @@ package mozilla.lockbox.presenter
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.action.OnboardingStatusAction
+import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
 
 interface OnboardingConfirmationView {
     val finishClicks: Observable<Unit>
+    val encryptionClicks: Observable<Unit>
 }
 
 class OnboardingConfirmationPresenter(
@@ -23,6 +25,11 @@ class OnboardingConfirmationPresenter(
     override fun onViewReady() {
         view.finishClicks
             .map { OnboardingStatusAction(false) }
+            .subscribe(dispatcher::dispatch)
+            .addTo(compositeDisposable)
+
+        view.encryptionClicks
+            .map { RouteAction.AppWebPage.FaqSecurity }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
     }

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -252,6 +252,8 @@ class RoutePresenter(
 
             Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_itemDetail_to_webview
 
+            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_setting_to_webview
+
             Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
 
             Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -250,6 +250,8 @@ class RoutePresenter(
             Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
             Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_itemList_to_webview
 
+            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_itemDetail_to_webview
+
             Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
 
             Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -229,6 +229,7 @@ class RoutePresenter(
         // the app will log.error.
         return when (Pair(from, to)) {
             Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_welcome_to_webPage
             Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
 
             Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -239,6 +239,7 @@ class RoutePresenter(
 
             Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
             Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_onboarding_confirmation_to_webView
 
             Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_to_itemList
             Pair(R.id.fragment_locked, R.id.fragment_welcome) -> R.id.action_locked_to_welcome

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -229,7 +229,7 @@ class RoutePresenter(
         // the app will log.error.
         return when (Pair(from, to)) {
             Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_welcome_to_webPage
+            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_webview
             Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
 
             Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
@@ -239,7 +239,7 @@ class RoutePresenter(
 
             Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
             Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_onboarding_confirmation_to_webView
+            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_to_webview
 
             Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_to_itemList
             Pair(R.id.fragment_locked, R.id.fragment_welcome) -> R.id.action_locked_to_welcome
@@ -249,11 +249,11 @@ class RoutePresenter(
             Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> R.id.action_itemList_to_accountSetting
             Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_itemList_to_locked
             Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
-            Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_itemList_to_webview
+            Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_to_webview
 
-            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_itemDetail_to_webview
+            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_to_webview
 
-            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_setting_to_webview
+            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_to_webview
 
             Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
 

--- a/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/SettingPresenter.kt
@@ -80,6 +80,11 @@ class SettingPresenter(
             dispatcher.dispatch(SettingAction.SendUsageData(newValue))
         }
 
+    private val learnMoreSendUsageDataObserver: Consumer<Unit>
+        get() = Consumer {
+            dispatcher.dispatch(RouteAction.AppWebPage.Privacy)
+        }
+
     override fun onViewReady() {
         settingStore.onEnablingFingerprint
             .subscribe {
@@ -150,6 +155,7 @@ class SettingPresenter(
                 subtitle = R.string.send_usage_data_summary,
                 contentDescription = R.string.send_usage_data,
                 buttonTitle = R.string.learn_more,
+                buttonObserver = learnMoreSendUsageDataObserver,
                 toggleDriver = settingStore.sendUsageData,
                 toggleObserver = sendUsageDataObserver
             ),

--- a/app/src/main/java/mozilla/lockbox/presenter/WelcomePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/WelcomePresenter.kt
@@ -14,6 +14,7 @@ import mozilla.lockbox.flux.Presenter
 
 interface WelcomeView {
     val getStartedClicks: Observable<Unit>
+    val learnMoreClicks: Observable<Unit>
 }
 
 class WelcomePresenter(
@@ -24,5 +25,9 @@ class WelcomePresenter(
         view.getStartedClicks
                 .subscribe { dispatcher.dispatch(RouteAction.Login) }
                 .addTo(compositeDisposable)
+
+        view.learnMoreClicks
+            .subscribe { dispatcher.dispatch(RouteAction.AppWebPage.FaqList) }
+            .addTo(compositeDisposable)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/WelcomePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/WelcomePresenter.kt
@@ -27,7 +27,7 @@ class WelcomePresenter(
                 .addTo(compositeDisposable)
 
         view.learnMoreClicks
-            .subscribe { dispatcher.dispatch(RouteAction.AppWebPage.FaqList) }
+            .subscribe { dispatcher.dispatch(RouteAction.AppWebPage.FaqWelcome) }
             .addTo(compositeDisposable)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -27,7 +27,17 @@ object Constant {
     }
 
     object Faq {
-        const val uri = "https://lockbox.firefox.com/faq.html#top"
+        const val uri = "https://lockbox.firefox.com/faq.html"
+        const val topUri = uri + "#top"
+        const val savedUri = uri + "#how-do-i-get-my-saved-logins-into-firefox-lockbox"
+        const val securityUri = uri + "#what-security-technologies-does-firefox-lockbox-use"
+        const val syncUri = uri + "#how-do-i-enable-sync-on-firefox"
+        const val createUri = uri + "#how-do-i-create-new-entries"
+        const val editUri = uri + "#how-do-i-edit-existing-entries"
+    }
+
+    object Privacy {
+        const val uri = "https://lockbox.firefox.com/privacy.html"
     }
 
     object SendFeedback {

--- a/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
@@ -77,7 +77,9 @@ class FilterFragment : BackableFragment(), FilterView {
     override val cancelButtonVisibility: Consumer<in Boolean>
         get() = view!!.cancelButton.visibility()
     override val itemSelection: Observable<ItemViewModel>
-        get() = adapter.clicks()
+        get() = adapter.itemClicks
+    override val noMatchingClicks: Observable<Unit>
+        get() = adapter.noMatchingEntriesClicks
 
     override fun updateItems(items: List<ItemViewModel>) {
         adapter.updateItems(items, true)

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -60,6 +60,9 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
     override val hostnameClicks: Observable<Unit>
         get() = view!!.inputHostname.clicks()
 
+    override val learnMoreClicks: Observable<Unit>
+        get() = view!!.detailLearnMore.clicks()
+
     override var isPasswordVisible: Boolean = false
         set(value) {
             assertOnUiThread()

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -36,6 +36,7 @@ import kotlinx.android.synthetic.main.fragment_item_list.*
 import kotlinx.android.synthetic.main.fragment_item_list.view.*
 import kotlinx.android.synthetic.main.fragment_warning.view.*
 import kotlinx.android.synthetic.main.list_cell_no_entries.view.*
+import kotlinx.android.synthetic.main.list_cell_no_matching.view.*
 import kotlinx.android.synthetic.main.nav_header.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.adapter.ItemListAdapter
@@ -148,6 +149,10 @@ class ItemListFragment : Fragment(), ItemListView {
      override val noEntriesClicks: Observable<Unit>
          // this will crash because view!!.noEntriesLearnMore must not be null
         get() = view!!.noEntriesLearnMore.clicks()
+
+    override val noMatchingClicks: Observable<Unit>
+        // this will crash because view!!.noMatchingLearnMore must not be null
+        get() = view!!.noMatchingLearnMore.clicks()
 
     override val itemSelection: Observable<ItemViewModel>
         get() = adapter.clicks()

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -7,21 +7,21 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
-import com.google.android.material.navigation.NavigationView
-import androidx.core.view.GravityCompat
-import androidx.drawerlayout.widget.DrawerLayout
-import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import androidx.appcompat.widget.Toolbar
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
+import android.widget.Spinner
+import androidx.appcompat.widget.Toolbar
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupWithNavController
-import android.widget.Spinner
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.navigation.NavigationView
 import com.jakewharton.rxbinding2.support.design.widget.itemSelections
 import com.jakewharton.rxbinding2.support.v4.widget.refreshes
 import com.jakewharton.rxbinding2.support.v7.widget.navigationClicks
@@ -35,18 +35,16 @@ import jp.wasabeef.picasso.transformations.CropCircleTransformation
 import kotlinx.android.synthetic.main.fragment_item_list.*
 import kotlinx.android.synthetic.main.fragment_item_list.view.*
 import kotlinx.android.synthetic.main.fragment_warning.view.*
-import kotlinx.android.synthetic.main.list_cell_no_entries.view.*
-import kotlinx.android.synthetic.main.list_cell_no_matching.view.*
 import kotlinx.android.synthetic.main.nav_header.view.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
+import mozilla.lockbox.action.Setting
 import mozilla.lockbox.adapter.ItemListAdapter
+import mozilla.lockbox.adapter.SortItemAdapter
+import mozilla.lockbox.model.AccountViewModel
 import mozilla.lockbox.model.ItemViewModel
 import mozilla.lockbox.presenter.ItemListPresenter
 import mozilla.lockbox.presenter.ItemListView
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import mozilla.lockbox.action.Setting
-import mozilla.lockbox.adapter.SortItemAdapter
-import mozilla.lockbox.model.AccountViewModel
 import mozilla.lockbox.support.showAndRemove
 
 @ExperimentalCoroutinesApi
@@ -146,7 +144,7 @@ class ItemListFragment : Fragment(), ItemListView {
     override val filterClicks: Observable<Unit>
         get() = view!!.filterButton.clicks()
 
-     override val noEntriesClicks: Observable<Unit>
+    override val noEntriesClicks: Observable<Unit>
         get() = adapter.noEntriesClicks
 
     override val itemSelection: Observable<ItemViewModel>

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -35,6 +35,7 @@ import jp.wasabeef.picasso.transformations.CropCircleTransformation
 import kotlinx.android.synthetic.main.fragment_item_list.*
 import kotlinx.android.synthetic.main.fragment_item_list.view.*
 import kotlinx.android.synthetic.main.fragment_warning.view.*
+import kotlinx.android.synthetic.main.list_cell_no_entries.view.*
 import kotlinx.android.synthetic.main.nav_header.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.adapter.ItemListAdapter
@@ -143,6 +144,10 @@ class ItemListFragment : Fragment(), ItemListView {
     // Protocol implementations
     override val filterClicks: Observable<Unit>
         get() = view!!.filterButton.clicks()
+
+     override val noEntriesClicks: Observable<Unit>
+         // this will crash because view!!.noEntriesLearnMore must not be null
+        get() = view!!.noEntriesLearnMore.clicks()
 
     override val itemSelection: Observable<ItemViewModel>
         get() = adapter.clicks()

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -147,15 +147,10 @@ class ItemListFragment : Fragment(), ItemListView {
         get() = view!!.filterButton.clicks()
 
      override val noEntriesClicks: Observable<Unit>
-         // this will crash because view!!.noEntriesLearnMore must not be null
-        get() = view!!.noEntriesLearnMore.clicks()
-
-    override val noMatchingClicks: Observable<Unit>
-        // this will crash because view!!.noMatchingLearnMore must not be null
-        get() = view!!.noMatchingLearnMore.clicks()
+        get() = adapter.noEntriesClicks
 
     override val itemSelection: Observable<ItemViewModel>
-        get() = adapter.clicks()
+        get() = adapter.itemClicks
 
     override val menuItemSelections: Observable<Int>
         get() {

--- a/app/src/main/java/mozilla/lockbox/view/OnboardingConfirmationFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/OnboardingConfirmationFragment.kt
@@ -7,6 +7,7 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
+import android.text.SpannableString
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,13 +19,22 @@ import mozilla.lockbox.presenter.OnboardingConfirmationPresenter
 import mozilla.lockbox.presenter.OnboardingConfirmationView
 
 class OnboardingConfirmationFragment : Fragment(), OnboardingConfirmationView {
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         presenter = OnboardingConfirmationPresenter(this)
 
         return inflater.inflate(R.layout.fragment_onboarding_confirmation, container, false)
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val securityLink = SpannableString(getString(R.string.security_link))
+        view.encryptionText.text = String.format(getString(R.string.security_description), securityLink)
+    }
+
     override val finishClicks: Observable<Unit>
         get() = view!!.finishButton.clicks()
+
+    override val encryptionClicks: Observable<Unit>
+        get() = view!!.encryptionText.clicks()
 }

--- a/app/src/main/java/mozilla/lockbox/view/OnboardingConfirmationFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/OnboardingConfirmationFragment.kt
@@ -7,7 +7,9 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
+import android.text.Spannable
 import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -28,8 +30,21 @@ class OnboardingConfirmationFragment : Fragment(), OnboardingConfirmationView {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val securityLink = SpannableString(getString(R.string.security_link))
-        view.encryptionText.text = String.format(getString(R.string.security_description), securityLink)
+        val linkColor = resources.getColor(R.color.blue_60_percent, null)
+        val securityLink = getString(R.string.security_link)
+        val securityText = String.format(getString(R.string.security_description), securityLink)
+        val spannableSecurityText = SpannableString(securityText)
+
+        val securityLinkStart = securityText.indexOf(securityLink)
+
+        spannableSecurityText.setSpan(
+            ForegroundColorSpan(linkColor),
+            securityLinkStart,
+            securityLinkStart + securityLink.length,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+
+        view.encryptionText.text = spannableSecurityText
     }
 
     override val finishClicks: Observable<Unit>

--- a/app/src/main/java/mozilla/lockbox/view/SettingViewHolder.kt
+++ b/app/src/main/java/mozilla/lockbox/view/SettingViewHolder.kt
@@ -10,6 +10,7 @@ import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
 import android.view.View
 import android.widget.Switch
+import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.widget.checkedChanges
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
@@ -85,6 +86,8 @@ class ToggleSettingViewHolder(val view: View) : SettingViewHolder(view) {
                 view.button.visibility = View.GONE
             }
         }
+
+    var buttonClicks: Observable<Unit> = view.button.clicks()
 
     var toggle: Switch = view.toggle
 

--- a/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/WelcomeFragment.kt
@@ -29,4 +29,7 @@ class WelcomeFragment : Fragment(), WelcomeView {
 
     override val getStartedClicks: Observable<Unit>
             get() = view!!.buttonGetStarted.clicks()
+
+    override val learnMoreClicks: Observable<Unit>
+            get() = view!!.textViewLearnMore.clicks()
 }

--- a/app/src/main/res/layout/fragment_item_detail.xml
+++ b/app/src/main/res/layout/fragment_item_detail.xml
@@ -164,7 +164,7 @@
     </androidx.cardview.widget.CardView>
 
     <TextView
-            android:id="@+id/placeholder_learn"
+            android:id="@+id/detailLearnMore"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="26dp"

--- a/app/src/main/res/layout/fragment_onboarding_confirmation.xml
+++ b/app/src/main/res/layout/fragment_onboarding_confirmation.xml
@@ -42,6 +42,7 @@
     />
 
     <TextView
+            android:id="@+id/encryptionText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="15sp"
@@ -54,7 +55,7 @@
             android:maxWidth="250dp"
             android:drawablePadding="8dp"
             android:drawableStart="@drawable/ic_security"
-            android:text="@string/security_description"
+            android:contentDescription="@string/security_content_description"
     />
 
     <TextView

--- a/app/src/main/res/layout/list_cell_no_entries.xml
+++ b/app/src/main/res/layout/list_cell_no_entries.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:orientation="vertical"
+              android:id="@+id/noEntries"
               android:background="@color/background_grey"
               android:layout_width="match_parent"
               android:layout_height="match_parent">
@@ -43,6 +49,7 @@
             android:text="@string/no_entries_description"/>
 
     <Button
+            android:id="@+id/noEntriesLearnMore"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"

--- a/app/src/main/res/layout/list_cell_no_matching.xml
+++ b/app/src/main/res/layout/list_cell_no_matching.xml
@@ -39,6 +39,7 @@
             android:text="@string/save_firefox_disclaimer"/>
 
     <Button
+        android:id="@+id/noMatchingLearnMore"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -130,7 +130,15 @@
             android:id="@+id/fragment_setting"
             android:name="mozilla.lockbox.view.SettingFragment"
             android:label="@string/nav_menu_settings"
-            tools:layout="@layout/fragment_setting"/>
+            tools:layout="@layout/fragment_setting">
+        <action
+                android:id="@+id/action_setting_to_webview"
+                app:destination="@id/fragment_webview"
+                app:enterAnim="@anim/slide_in_bottom"
+                app:exitAnim="@anim/none"
+                app:popExitAnim="@anim/slide_out_bottom"
+                app:popEnterAnim="@anim/none"/>
+    </fragment>
 
     <fragment
             android:id="@+id/fragment_webview"

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -64,6 +64,13 @@
                 app:launchSingleTop="true"
                 app:destination="@id/fragment_item_list"
                 app:popUpToInclusive="true"/>
+        <action
+                android:id="@+id/action_onboarding_confirmation_to_webView"
+                app:destination="@id/fragment_webview"
+                app:enterAnim="@anim/slide_in_bottom"
+                app:exitAnim="@anim/none"
+                app:popExitAnim="@anim/slide_out_bottom"
+                app:popEnterAnim="@anim/none"/>
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -18,13 +18,6 @@
         <action
                 android:id="@+id/action_welcome_to_fxaLogin"
                 app:destination="@id/fragment_fxa_login"/>
-        <action
-                android:id="@+id/action_welcome_to_webPage"
-                app:destination="@id/fragment_webview"
-                app:enterAnim="@anim/slide_in_bottom"
-                app:exitAnim="@anim/none"
-                app:popExitAnim="@anim/slide_out_bottom"
-                app:popEnterAnim="@anim/none"/>
     </fragment>
 
     <fragment
@@ -64,13 +57,6 @@
                 app:launchSingleTop="true"
                 app:destination="@id/fragment_item_list"
                 app:popUpToInclusive="true"/>
-        <action
-                android:id="@+id/action_onboarding_confirmation_to_webView"
-                app:destination="@id/fragment_webview"
-                app:enterAnim="@anim/slide_in_bottom"
-                app:exitAnim="@anim/none"
-                app:popExitAnim="@anim/slide_out_bottom"
-                app:popEnterAnim="@anim/none"/>
     </fragment>
 
     <fragment
@@ -83,13 +69,6 @@
         <action
                 android:id="@+id/action_itemList_to_setting"
                 app:destination="@id/fragment_setting"
-                app:enterAnim="@anim/slide_in_bottom"
-                app:exitAnim="@anim/none"
-                app:popExitAnim="@anim/slide_out_bottom"
-                app:popEnterAnim="@anim/none"/>
-        <action
-                android:id="@+id/action_itemList_to_webview"
-                app:destination="@id/fragment_webview"
                 app:enterAnim="@anim/slide_in_bottom"
                 app:exitAnim="@anim/none"
                 app:popExitAnim="@anim/slide_out_bottom"
@@ -124,13 +103,6 @@
                 android:name="itemId"
                 android:defaultValue="MISSING_ID"
                 app:argType="string"/>
-        <action
-                android:id="@+id/action_itemDetail_to_webview"
-                app:destination="@id/fragment_webview"
-                app:enterAnim="@anim/slide_in_bottom"
-                app:exitAnim="@anim/none"
-                app:popExitAnim="@anim/slide_out_bottom"
-                app:popEnterAnim="@anim/none"/>
     </fragment>
 
     <fragment
@@ -138,13 +110,6 @@
             android:name="mozilla.lockbox.view.SettingFragment"
             android:label="@string/nav_menu_settings"
             tools:layout="@layout/fragment_setting">
-        <action
-                android:id="@+id/action_setting_to_webview"
-                app:destination="@id/fragment_webview"
-                app:enterAnim="@anim/slide_in_bottom"
-                app:exitAnim="@anim/none"
-                app:popExitAnim="@anim/slide_out_bottom"
-                app:popEnterAnim="@anim/none"/>
     </fragment>
 
     <fragment
@@ -212,4 +177,12 @@
             app:launchSingleTop="true"
             app:popUpTo="@+id/fragment_welcome"
             app:popUpToInclusive="true"/>
+
+    <action
+            android:id="@+id/action_to_webview"
+            app:destination="@id/fragment_webview"
+            app:enterAnim="@anim/slide_in_bottom"
+            app:exitAnim="@anim/none"
+            app:popExitAnim="@anim/slide_out_bottom"
+            app:popEnterAnim="@anim/none"/>
 </navigation>

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -117,6 +117,13 @@
                 android:name="itemId"
                 android:defaultValue="MISSING_ID"
                 app:argType="string"/>
+        <action
+                android:id="@+id/action_itemDetail_to_webview"
+                app:destination="@id/fragment_webview"
+                app:enterAnim="@anim/slide_in_bottom"
+                app:exitAnim="@anim/none"
+                app:popExitAnim="@anim/slide_out_bottom"
+                app:popEnterAnim="@anim/none"/>
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -18,6 +18,13 @@
         <action
                 android:id="@+id/action_welcome_to_fxaLogin"
                 app:destination="@id/fragment_fxa_login"/>
+        <action
+                android:id="@+id/action_welcome_to_webPage"
+                app:destination="@id/fragment_webview"
+                app:enterAnim="@anim/slide_in_bottom"
+                app:exitAnim="@anim/none"
+                app:popExitAnim="@anim/slide_out_bottom"
+                app:popEnterAnim="@anim/none"/>
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,6 +229,7 @@
     <string name="security_description">Sync between devices with secure 256-bit encryption</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
     <string name="convenience_description">Unlock the app with ease using your fingerprint</string>
+    <string name="privacy">Privacy</string>
 
     <!-- This is the prompt when autofill is triggered, and Lockbox is locked. -->
     <string name="autofill_authenticate_cta">Unlock Lockbox</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,9 +226,7 @@
     <!-- This description of the app functionality is shown on the final onboarding screen. -->
     <string name="access_description">Access logins saved to Firefox from your phone</string>
     <!-- This is an accessible content description for the security information link text. -->
-    <string name="security_content_description">This is a link to a description of security practices in Mozilla
-        Lockbox.
-    </string>
+    <string name="security_content_description">This is a link to a description of security practices in Firefox Lockbox.</string>
     <!-- This description of the app security is shown on the final onboarding screen. -->
     <string name="security_description">Sync between devices with secure %s</string>
     <!-- This text is displayed as a link in the security description. -->
@@ -239,11 +237,11 @@
     <!-- This header appears above the Privacy page of the mozilla-lockbox website. -->
     <string name="privacy">Privacy</string>
 
-    <!-- This is the prompt when autofill is triggered, and Lockbox is locked. -->
-    <string name="autofill_authenticate_cta">Unlock Lockbox</string>
+    <!-- This is the prompt when autofill is triggered, and Firefox Lockbox is locked. -->
+    <string name="autofill_authenticate_cta">Unlock Firefox Lockbox</string>
     <!-- This is the error message when autofill is triggered but no domain is detected. This is unlikely. -->
     <string name="autofill_error_no_hostname">Unexpected hostname format</string>
     <!-- This is the prompt when autofill is triggered, Lockbox is unlocked, and no passwords are detected. -->
-    <string name="autofill_search_cta">Search Lockbox</string>
+    <string name="autofill_search_cta">Search Firefox Lockbox</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -225,10 +225,18 @@
     <string name="finish">Finish</string>
     <!-- This description of the app functionality is shown on the final onboarding screen. -->
     <string name="access_description">Access logins saved to Firefox from your phone</string>
+    <!-- This is an accessible content description for the security information link text. -->
+    <string name="security_content_description">This is a link to a description of security practices in Mozilla
+        Lockbox.
+    </string>
     <!-- This description of the app security is shown on the final onboarding screen. -->
-    <string name="security_description">Sync between devices with secure 256-bit encryption</string>
+    <string name="security_description">Sync between devices with secure %s</string>
+    <!-- This text is displayed as a link in the security description. -->
+    <string name="security_link">256-bit encryption</string>
     <!-- This description of the app convenience is shown on the final onboarding screen. -->
     <string name="convenience_description">Unlock the app with ease using your fingerprint</string>
+
+    <!-- This header appears above the Privacy page of the mozilla-lockbox website. -->
     <string name="privacy">Privacy</string>
 
     <!-- This is the prompt when autofill is triggered, and Lockbox is locked. -->

--- a/app/src/test/java/mozilla/lockbox/adapter/ItemListAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/ItemListAdapterTest.kt
@@ -9,6 +9,10 @@ package mozilla.lockbox.adapter
 import android.content.Context
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import io.reactivex.observers.TestObserver
+import kotlinx.android.synthetic.main.list_cell_no_entries.view.*
+import kotlinx.android.synthetic.main.list_cell_no_matching.view.*
+import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.model.ItemViewModel
 import mozilla.lockbox.view.ItemViewHolder
 import org.junit.Assert
@@ -22,6 +26,10 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(packageName = "mozilla.lockbox")
 class ItemListAdapterTest {
+
+    val itemObserver = TestObserver.create<ItemViewModel>()
+    val noEntriesObserver = TestObserver.create<Unit>()
+    val noMatchingObserver = TestObserver.create<Unit>()
 
     val subject = ItemListAdapter()
     private lateinit var context: Context
@@ -38,6 +46,10 @@ class ItemListAdapterTest {
         context = RuntimeEnvironment.application
         parent = RecyclerView(context)
         parent.layoutManager = LinearLayoutManager(context)
+        subject.itemClicks.subscribe(itemObserver)
+        subject.noEntriesClicks.subscribe(noEntriesObserver)
+        subject.noMatchingEntriesClicks.subscribe(noMatchingObserver)
+
         subject.updateItems(list)
     }
 
@@ -64,6 +76,45 @@ class ItemListAdapterTest {
         val viewHolder = subject.onCreateViewHolder(parent, 1)
 
         subject.onBindViewHolder(viewHolder, 0)
+    }
+
+    @Test
+    fun onBindViewHolder_populatedList_clicks() {
+        val viewHolder = subject.onCreateViewHolder(parent, 0) as ItemViewHolder
+        val indexOfItem = 1
+        val expectedItemViewModel = list[indexOfItem]
+
+        subject.onBindViewHolder(viewHolder, indexOfItem)
+
+        Assert.assertEquals(expectedItemViewModel, viewHolder.itemViewModel)
+
+        viewHolder.containerView.performClick()
+
+        itemObserver.assertLastValue(expectedItemViewModel)
+    }
+
+    @Test
+    fun onBindViewHolder_emptyList_clicks() {
+        subject.updateItems(emptyList())
+        val viewHolder = subject.onCreateViewHolder(parent, 2)
+
+        subject.onBindViewHolder(viewHolder, 0)
+
+        viewHolder.containerView.noEntriesLearnMore.performClick()
+
+        noEntriesObserver.assertValueCount(1)
+    }
+
+    @Test
+    fun onBindViewHolder_emptyFilteringList_clicks() {
+        subject.updateItems(emptyList(), true)
+        val viewHolder = subject.onCreateViewHolder(parent, 1)
+
+        subject.onBindViewHolder(viewHolder, 0)
+
+        viewHolder.containerView.noMatchingLearnMore.performClick()
+
+        noMatchingObserver.assertValueCount(1)
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/presenter/FilterPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FilterPresenterTest.kt
@@ -32,6 +32,7 @@ class FilterPresenterTest {
         val cancelButtonStub = PublishSubject.create<Unit>()
         val cancelButtonVisibilityStub = TestObserver<Boolean>()
         val itemSelectionStub = PublishSubject.create<ItemViewModel>()
+        val noMatchingClickStub = PublishSubject.create<Unit>()
 
         var updateItemsArgument: List<ItemViewModel>? = null
 
@@ -41,6 +42,7 @@ class FilterPresenterTest {
         override val cancelButtonVisibility: Consumer<in Boolean> =
             TestConsumer(cancelButtonVisibilityStub)
         override val itemSelection: Observable<ItemViewModel> = itemSelectionStub
+        override val noMatchingClicks: Observable<Unit> = noMatchingClickStub
 
         override fun updateItems(items: List<ItemViewModel>) {
             updateItemsArgument = items
@@ -142,5 +144,12 @@ class FilterPresenterTest {
         view.itemSelectionStub.onNext(model)
 
         dispatcherObserver.assertValue(RouteAction.ItemDetail(guid))
+    }
+
+    @Test
+    fun noMatchingClicks() {
+        view.noMatchingClickStub.onNext(Unit)
+
+        dispatcherObserver.assertValue(RouteAction.AppWebPage.FaqCreate)
     }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -43,6 +43,10 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class ItemDetailPresenterTest {
     class FakeView : ItemDetailView {
+        val learnMoreClickStub = PublishSubject.create<Unit>()
+        override val learnMoreClicks: Observable<Unit>
+            get() = learnMoreClickStub
+
         private val retryButtonStub = PublishSubject.create<Unit>()
         override val retryNetworkConnectionClicks: Observable<Unit>
             get() = retryButtonStub
@@ -187,5 +191,11 @@ class ItemDetailPresenterTest {
         value.onNext(true)
 
         isConnectedObserver.assertValue(true)
+    }
+
+    @Test
+    fun `learn more clicks`() {
+        view.learnMoreClickStub.onNext(Unit)
+        dispatcherObserver.assertLastValue(RouteAction.AppWebPage.FaqEdit)
     }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
@@ -100,6 +100,7 @@ open class ItemListPresenterTest {
         val menuItemSelectionStub = PublishSubject.create<Int>()
         val itemSelectedStub = PublishSubject.create<ItemViewModel>()
         val filterClickStub = PublishSubject.create<Unit>()
+        val noEntriesClickStub = PublishSubject.create<Unit>()
         val sortItemSelectionStub = PublishSubject.create<Setting.ItemListSort>()
         val disclaimerActionStub = PublishSubject.create<AlertState>()
         val lockNowSelectionStub = PublishSubject.create<Unit>()
@@ -119,6 +120,9 @@ open class ItemListPresenterTest {
 
         override val lockNowClick: Observable<Unit>
             get() = lockNowSelectionStub
+
+        override val noEntriesClicks: Observable<Unit>
+            get() = noEntriesClickStub
 
         override fun updateAccountProfile(profile: AccountViewModel) {
             accountViewModel = AccountViewModel(
@@ -298,6 +302,12 @@ open class ItemListPresenterTest {
     fun `filter clicks cause RouteAction Filter`() {
         view.filterClickStub.onNext(Unit)
         Assert.assertTrue(dispatcherObserver.values().last() is RouteAction.Filter)
+    }
+
+    @Test
+    fun `no matching entries clicks routes to FAQ`() {
+        view.noEntriesClickStub.onNext(Unit)
+        dispatcherObserver.assertLastValue(RouteAction.AppWebPage.FaqSync)
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/presenter/OnboardingConfirmationPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/OnboardingConfirmationPresenterTest.kt
@@ -11,6 +11,7 @@ import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
 import mozilla.lockbox.action.OnboardingStatusAction
+import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
@@ -19,6 +20,7 @@ import org.junit.Test
 
 class OnboardingConfirmationPresenterTest {
     class FakeOnboardingConfirmationView : OnboardingConfirmationView {
+        override val encryptionClicks: Observable<Unit> = PublishSubject.create()
         override val finishClicks: Observable<Unit> = PublishSubject.create()
     }
 
@@ -40,5 +42,12 @@ class OnboardingConfirmationPresenterTest {
         (view.finishClicks as Subject).onNext(Unit)
 
         dispatcherObserver.assertLastValue(OnboardingStatusAction(false))
+    }
+
+    @Test
+    fun encryptionClicks() {
+        (view.encryptionClicks as Subject).onNext(Unit)
+
+        dispatcherObserver.assertLastValue(RouteAction.AppWebPage.FaqSecurity)
     }
 }

--- a/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/SettingPresenterTest.kt
@@ -280,6 +280,16 @@ class SettingPresenterTest {
     }
 
     @Test
+    fun `learn more button in sendUsageData tapped`() {
+        Mockito.`when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
+        subject.onResume()
+
+        (view.settingItem!![1] as ToggleSettingConfiguration).buttonObserver!!.accept(Unit)
+
+        dispatcherObserver.assertLastValue(RouteAction.AppWebPage.Privacy)
+    }
+
+    @Test
     fun `autoLockTime update requested`() {
         Mockito.`when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
         subject.onResume()

--- a/app/src/test/java/mozilla/lockbox/presenter/WelcomePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/WelcomePresenterTest.kt
@@ -10,31 +10,43 @@ import io.reactivex.subjects.PublishSubject
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
+import org.junit.Before
 import org.junit.Test
 
 class WelcomePresenterTest {
     class FakeView : WelcomeView {
-        val tapStub: PublishSubject<Unit> = PublishSubject.create<Unit>()
+        val learnMoreStub = PublishSubject.create<Unit>()
+        override val learnMoreClicks: Observable<Unit> = learnMoreStub
 
+        val getStartedStub: PublishSubject<Unit> = PublishSubject.create<Unit>()
         override val getStartedClicks: Observable<Unit>
-            get() = tapStub
+            get() = getStartedStub
     }
 
     val view = FakeView()
     val dispatcher = Dispatcher()
+
+    val dispatcherObserver = TestObserver.create<Action>()
+
     val subject = WelcomePresenter(view, dispatcher)
 
-    @Test
-    fun onViewReady() {
-        val testObserver = TestObserver.create<Action>()
-
-        val subscription = dispatcher.register.subscribeWith(testObserver)
-
+    @Before
+    fun setUp() {
+        dispatcher.register.subscribe(dispatcherObserver)
         subject.onViewReady()
-        view.tapStub.onNext(Unit)
+    }
 
-        testObserver.assertValue(RouteAction.Login)
+    @Test
+    fun `get started clicks`() {
+        view.getStartedStub.onNext(Unit)
 
-        subscription.dispose()
+        dispatcherObserver.assertValue(RouteAction.Login)
+    }
+
+    @Test
+    fun `learn more clicks`() {
+        view.learnMoreStub.onNext(Unit)
+
+        dispatcherObserver.assertValue(RouteAction.AppWebPage.FaqWelcome)
     }
 }


### PR DESCRIPTION
Fixes #37

## Testing and Review Notes

Ideally, all of the FAQ pages will slide up from the bottom -- please let me know if you find a case where that's not happening. Also, I cut a corner with the security text from the onboarding confirmation screen - all of the text is a link, not just the `256-bit encryption` part, but hopefully that won't be that noticable.


## Work Remaining

- [x] add click on Welcome text
  - [x] set proper URL `#how-do-i-get-my-saved-logins-into-firefox-lockbox`
- [x] add click on "You're All Set" onboarding
  - [x] set proper URL `#what-security-technologies-does-firefox-lockbox-use`
  - [x] add action to nav graph
- [x] add click on No Entries Found button
  - [x] fix "null" crash unable to access this?
  - [x] set proper URL `* #how-do-i-enable-sync-on-firefox`
- [x] add click on No Matching button
  - [x] fix "null" crash unable to access this?
  - [x] set proper URL `#how-do-i-create-new-entries`
- [x] add click on Entry Detail
  - [x] set proper URL `#how-do-i-edit-existing-entries`
  - [x] add to navigation graph/map
- [x] add click on Send Usage Data
  - [x] set proper URL
  - [x] add action to nav graph

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI