### PR TITLE
Use the public suffix list to be less permissive on matching

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     implementation "org.mozilla.components:service-telemetry:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-dataprotect:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:${rootProject.ext.android_components_version}"
+    implementation "org.mozilla.components:lib-publicsuffixlist:${rootProject.ext.android_components_version}"
     implementation 'io.sentry:sentry-android:1.7.14'
     implementation 'com.github.magiepooh:recycler-itemdecoration:1.1.1@aar'
     implementation 'com.squareup.picasso:picasso:2.71828'

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -79,7 +79,7 @@ class LockboxAutofillService(
         // convert a list of ServerPasswords into a list of (psl+1, ServerPassword)
         val passwords = dataStore.list
             .take(1)
-            .switchMap {serverPasswords ->
+            .switchMap { serverPasswords ->
                 val parsedPasswords = serverPasswords
                     .map { serverPwd ->
                         pslSupport.fromOrigin(serverPwd.hostname)
@@ -92,14 +92,13 @@ class LockboxAutofillService(
 
                 when (serverPasswords.size) {
                     0 -> Observable.just(emptyList<FillablePassword>())
-                    else ->Observable.zipIterable(
+                    else -> Observable.zipIterable(
                         parsedPasswords,
                         zipper,
                         false,
                         serverPasswords.size
                     )
                 }
-
             }
             .take(1)
 
@@ -131,11 +130,6 @@ class LockboxAutofillService(
         Observables.combineLatest(expectedDomain, passwords)
             .subscribe(doNext, doError)
             .addTo(compositeDisposable)
-    }
-
-    private fun domainFromPackage(packageName: String): String {
-        // naively assume package labels are split by `ASCII PERIOD (.)`
-        return packageName.split(".").asReversed().joinToString(".")
     }
 
     private fun buildFillResponse(

--- a/app/src/main/java/mozilla/lockbox/support/PulicSuffixSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/PulicSuffixSupport.kt
@@ -1,0 +1,67 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *
+ */
+
+package mozilla.lockbox.support
+
+import io.reactivex.Observable
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.rx2.asMaybe
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
+import mozilla.lockbox.log
+import java.net.IDN
+import java.net.URI
+import kotlin.coroutines.CoroutineContext
+
+@ExperimentalCoroutinesApi
+open class PublicSuffixSupport(
+    private val psl: PublicSuffixList,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
+) {
+    private val exceptionHandler: CoroutineExceptionHandler
+        get() = CoroutineExceptionHandler { _, e ->
+            log.error(
+                message = "unexpected error in PublicSuffixList usage",
+                throwable = e
+            )
+        }
+    private val coroutineContext: CoroutineContext
+        get() = dispatcher + exceptionHandler
+
+    fun fromWebDomain(domain: String?): Observable<PublicSuffix> {
+        val fullDomain = domain ?: ""
+        return psl.getPublicSuffixPlusOne(fullDomain)
+            .asMaybe(coroutineContext)
+            .toSingle("")
+            .flatMapObservable { Observable.just(PublicSuffix(it, fullDomain)) }
+    }
+
+    fun fromOrigin(origin: String): Observable<PublicSuffix> {
+        val domain = URI.create(origin).host
+        return fromWebDomain(domain)
+    }
+    fun fromPackageName(pkg: String): Observable<PublicSuffix> {
+        val domain = pkg
+            .split('.')
+            .asReversed()
+            .joinToString(".")
+        return fromWebDomain(domain)
+    }
+}
+
+data class PublicSuffix(
+    val topDomain: String,
+    val fullDomain: String
+) {
+    fun isEmpty(): Boolean = topDomain.isEmpty()
+    fun isNotEmpty(): Boolean = topDomain.isNotEmpty()
+    fun matches(expected: PublicSuffix): Boolean
+        = expected.topDomain.equals(expected.topDomain, true)
+}

--- a/app/src/test/java/mozilla/lockbox/extensions/Observer+.kt
+++ b/app/src/test/java/mozilla/lockbox/extensions/Observer+.kt
@@ -8,12 +8,14 @@ package mozilla.lockbox.extensions
 
 import io.reactivex.observers.TestObserver
 
-fun <T> TestObserver<T>.assertLastValue(expectedValue: T) {
+fun <T> TestObserver<T>.assertLastValue(expectedValue: T): TestObserver<T> {
     val count = this.valueCount()
     this.assertValueAt(count - 1, expectedValue)
+    return this
 }
 
-fun <T> TestObserver<T>.assertLastValueMatches(expectedPredicate: (value: T) -> Boolean) {
+fun <T> TestObserver<T>.assertLastValueMatches(expectedPredicate: (value: T) -> Boolean): TestObserver<T> {
     val count = this.valueCount()
     this.assertValueAt(count - 1, expectedPredicate)
+    return this
 }

--- a/app/src/test/java/mozilla/lockbox/support/PublicSuffixSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/PublicSuffixSupportTest.kt
@@ -1,0 +1,309 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *
+ */
+
+package mozilla.lockbox.support
+
+import android.content.Context
+import io.reactivex.observers.TestObserver
+import io.reactivex.rxkotlin.Observables
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
+import mozilla.lockbox.DisposingTest
+import mozilla.lockbox.extensions.assertLastValueMatches
+import mozilla.lockbox.presenter.TestApplication
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+typealias PublicSuffixPair = Pair<PublicSuffix, PublicSuffix>
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class)
+class PublicSuffixSupportTest : DisposingTest() {
+    private val appContext: Context = RuntimeEnvironment.application
+    private val support = PublicSuffixSupport(PublicSuffixList(appContext))
+
+    @Test
+    fun `test from web domain`() {
+        var psObserver: TestObserver<PublicSuffix> = createTestObserver()
+        support.fromWebDomain("example.com")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.com" }
+            .assertLastValueMatches { it.fullDomain == "example.com" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromWebDomain("www.example.com")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.com" }
+            .assertLastValueMatches { it.fullDomain == "www.example.com" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromWebDomain("cats.example.co.uk")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.co.uk" }
+            .assertLastValueMatches { it.fullDomain == "cats.example.co.uk" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromWebDomain("lockbox.mozilla")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "lockbox.mozilla" }
+            .assertLastValueMatches { it.fullDomain == "lockbox.mozilla" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromWebDomain("blogspot.com")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "blogspot.com" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromWebDomain("")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromWebDomain(null)
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+    }
+
+    @Test
+    fun `test from package name`() {
+        var psObserver: TestObserver<PublicSuffix> = createTestObserver()
+        support.fromPackageName("com.example")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.com" }
+            .assertLastValueMatches { it.fullDomain == "example.com" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromPackageName("com.example.android")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.com" }
+            .assertLastValueMatches { it.fullDomain == "android.example.com" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromPackageName("uk.co.example.cats")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.co.uk" }
+            .assertLastValueMatches { it.fullDomain == "cats.example.co.uk" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromPackageName("mozilla.lockbox")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "lockbox.mozilla" }
+            .assertLastValueMatches { it.fullDomain == "lockbox.mozilla" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromPackageName("com.blogspot")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "blogspot.com" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromPackageName("")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromPackageName(null)
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+    }
+
+    @Test
+    fun `test from hostname origin`() {
+        var psObserver: TestObserver<PublicSuffix> = createTestObserver()
+        support.fromOrigin("https://example.com")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.com" }
+            .assertLastValueMatches { it.fullDomain == "example.com" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromOrigin("http://example.com")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.com" }
+            .assertLastValueMatches { it.fullDomain == "example.com" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+            .await()
+
+        psObserver = createTestObserver()
+        support.fromOrigin("https://www.example.com")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.com" }
+            .assertLastValueMatches { it.fullDomain == "www.example.com" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromOrigin("https://cats.example.co.uk")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "example.co.uk" }
+            .assertLastValueMatches { it.fullDomain == "cats.example.co.uk" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromOrigin("https://lockbox.mozilla")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "lockbox.mozilla" }
+            .assertLastValueMatches { it.fullDomain == "lockbox.mozilla" }
+            .assertLastValueMatches { !it.isEmpty() }
+            .assertLastValueMatches { it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromOrigin("https://blogspot.com")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "blogspot.com" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromOrigin("")
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+
+        psObserver = createTestObserver()
+        support.fromOrigin(null)
+            .subscribe(psObserver)
+        psObserver.await()
+            .assertLastValueMatches { it.topDomain == "" }
+            .assertLastValueMatches { it.fullDomain == "" }
+            .assertLastValueMatches { it.isEmpty() }
+            .assertLastValueMatches { !it.isNotEmpty() }
+    }
+
+    @Test
+    fun `test matching`() {
+        var expected = support.fromWebDomain("www.example.com")
+            .take(1)
+        var candidate = support.fromWebDomain("www.example.com")
+            .take(1)
+        var matchObserver: TestObserver<PublicSuffixPair> = createTestObserver()
+        Observables.combineLatest(expected, candidate)
+            .subscribe(matchObserver)
+        matchObserver.await()
+            .assertLastValueMatches { it.first.matches(it.second) }
+            .assertLastValueMatches { it.second.matches(it.first) }
+
+        candidate = support.fromWebDomain("mobile.example.com")
+            .take(1)
+        matchObserver = createTestObserver()
+        Observables.combineLatest(expected, candidate)
+            .subscribe(matchObserver)
+        matchObserver.await()
+            .assertLastValueMatches { it.first.matches(it.second) }
+            .assertLastValueMatches { it.second.matches(it.first) }
+
+        candidate = support.fromPackageName("com.example.android")
+            .take(1)
+        matchObserver = createTestObserver()
+        Observables.combineLatest(expected, candidate)
+            .subscribe(matchObserver)
+        matchObserver.await()
+            .assertLastValueMatches { it.first.matches(it.second) }
+            .assertLastValueMatches { it.second.matches(it.first) }
+
+        candidate = support.fromOrigin("https://login.example.com")
+            .take(1)
+        matchObserver = createTestObserver()
+        Observables.combineLatest(expected, candidate)
+            .subscribe(matchObserver)
+        matchObserver.await()
+            .assertLastValueMatches { it.first.matches(it.second) }
+            .assertLastValueMatches { it.second.matches(it.first) }
+
+        candidate = support.fromWebDomain("areweloggedinyet.com")
+            .take(1)
+        matchObserver = createTestObserver()
+        Observables.combineLatest(expected, candidate)
+            .subscribe(matchObserver)
+        matchObserver.await()
+            .assertLastValueMatches { !it.first.matches(it.second) }
+            .assertLastValueMatches { !it.second.matches(it.first) }
+
+        expected = support.fromWebDomain("cats.example.co.uk")
+            .take(1)
+        matchObserver = createTestObserver()
+        Observables.combineLatest(expected, candidate)
+            .subscribe(matchObserver)
+        matchObserver.await()
+            .assertLastValueMatches { !it.first.matches(it.second) }
+            .assertLastValueMatches { !it.second.matches(it.first) }
+
+        candidate = support.fromWebDomain("cats.example.co.uk")
+            .take(1)
+        matchObserver = createTestObserver()
+        Observables.combineLatest(expected, candidate)
+            .subscribe(matchObserver)
+        matchObserver.await()
+            .assertLastValueMatches { it.first.matches(it.second) }
+            .assertLastValueMatches { it.second.matches(it.first) }
+    }
+}


### PR DESCRIPTION
Fixes #375

This uses `lib-publicsuffixlist` from Android-Components to tighten up the matching.

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

Connected to #???

_(Optional: other issues or pull requests related to this, but merging should not close it)_

## Testing and Review Notes

_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_


## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- ~request the "UX" team perform a design review (if/when applicable)~
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- ~check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI~