### PR TITLE
Handle Canceling Auth during Autofill

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/AuthPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AuthPresenter.kt
@@ -52,11 +52,14 @@ class AuthPresenter(
 
         lockedStore.onAuthentication
             .subscribe {
-                if (it is FingerprintAuthAction.OnAuthentication) {
-                    when (it.authCallback) {
-                        is FingerprintAuthCallback.OnAuth -> unlock()
-                        is FingerprintAuthCallback.OnError -> view.unlockFallback()
+                when (it) {
+                    is FingerprintAuthAction.OnAuthentication -> {
+                        when (it.authCallback) {
+                            is FingerprintAuthCallback.OnAuth -> unlock()
+                            is FingerprintAuthCallback.OnError -> view.unlockFallback()
+                        }
                     }
+                    is FingerprintAuthAction.OnCancel -> view.setFillResponseAndFinish(null)
                 }
             }
             .addTo(compositeDisposable)

--- a/app/src/test/java/mozilla/lockbox/presenter/AuthPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AuthPresenterTest.kt
@@ -1,0 +1,82 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.presenter
+
+import android.content.Context
+import android.service.autofill.FillResponse
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+import mozilla.lockbox.DisposingTest
+import mozilla.lockbox.ParsedStructure
+import mozilla.lockbox.action.FingerprintAuthAction
+import mozilla.lockbox.autofill.FillResponseBuilder
+import mozilla.lockbox.extensions.assertLastValueMatches
+import mozilla.lockbox.store.LockedStore
+import mozilla.lockbox.support.Optional
+import mozilla.lockbox.support.asOptional
+import org.junit.Before
+import org.junit.Test
+
+internal class AuthPresenterTest : DisposingTest() {
+    class FakeLockedStore : LockedStore() {
+        internal val _onAuth = PublishSubject.create<FingerprintAuthAction>()
+        override val onAuthentication: Observable<FingerprintAuthAction>
+            get() = _onAuth
+    }
+
+    class FakeAuthView : AuthView {
+        override fun showAuthDialog() {
+            TODO("not implemented")
+        }
+
+        override fun unlockFallback() {
+            TODO("not implemented")
+        }
+
+        internal val _onFinish = PublishSubject.create<Optional<FillResponse>>()
+        override fun setFillResponseAndFinish(fillResponse: FillResponse?) {
+            _onFinish.onNext(fillResponse.asOptional())
+        }
+
+        internal val _onUnlockConfirm = PublishSubject.create<Boolean>()
+        override val unlockConfirmed: Observable<Boolean>
+            get() = _onUnlockConfirm
+
+        override val context: Context
+            get() = TODO("not implemented")
+    }
+
+    private val lockedStore = FakeLockedStore()
+    private val view = FakeAuthView()
+    private val responseBuilder = FillResponseBuilder(ParsedStructure(packageName = "mozilla.lockbox.testing"))
+
+    private lateinit var presenter: AuthPresenter
+
+    @Before
+    fun setUp() {
+        presenter = AuthPresenter(view, responseBuilder, lockedStore = lockedStore)
+        presenter.onViewReady()
+    }
+
+    @Test
+    fun `tells view to finish with null on unlockConfirmed(false)`() {
+        val obsFinish = createTestObserver<Optional<FillResponse>>()
+        view._onFinish.subscribe(obsFinish)
+
+        view._onUnlockConfirm.onNext(false)
+        obsFinish.assertLastValueMatches { it.value == null }
+    }
+
+    @Test
+    fun `tells view to finish with null on fingerprint auth canceled`() {
+        val obsFinish = createTestObserver<Optional<FillResponse>>()
+        view._onFinish.subscribe(obsFinish)
+
+        lockedStore._onAuth.onNext(FingerprintAuthAction.OnCancel)
+        obsFinish.assertLastValueMatches { it .value == null }
+    }
+}

--- a/app/src/test/java/mozilla/lockbox/presenter/AuthPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AuthPresenterTest.kt
@@ -62,6 +62,8 @@ internal class AuthPresenterTest : DisposingTest() {
         presenter.onViewReady()
     }
 
+    // TODO: Test the other paths
+
     @Test
     fun `tells view to finish with null on unlockConfirmed(false)`() {
         val obsFinish = createTestObserver<Optional<FillResponse>>()


### PR DESCRIPTION
Fixes #449

Ensure that if the user cancels authenticating during autofill, control returns back to the sending activity.

**NOTE**: this PR is not addressing any of the visual discrepancies in #421 or #436 
**NOTE**: The added tests are only covering the changes specific to this PR, even though the whole -Test class is new (to be addressed via #465)

_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_

## Testing and Review Notes

* Start with Lockbox app in the locked state, then open an app for autofill
* The user is returned to the originating app if dismissed:

    - tapping system "Back" button
    - tapping "Cancel" button if present
    - (for fingerprint unlock) tapping outside of the dialog

## Screenshots or Videos
Capture illustrates the following:
1. autofill prompt to unlock -> tap
2. overlay fingerprint unlock -> tap cancel
3. autofill prompt to unlock -> tap
4. overlay fingerprint unlock -> scan print
5. autofill search

![autofilllock-print-2019-02-19](https://user-images.githubusercontent.com/757401/53044900-816a6000-3449-11e9-8f3d-3ad7bf5ef163.gif)


## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
