### PR TITLE
445: Changing network warning visibility to automatically hide

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/AppWebPagePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppWebPagePresenter.kt
@@ -16,7 +16,7 @@ import mozilla.lockbox.store.NetworkStore
 
 interface WebPageView {
     var webViewObserver: Consumer<String>?
-    val retryNetworkConnectionClicks: Observable<Unit>
+//    val retryNetworkConnectionClicks: Observable<Unit>
     fun handleNetworkError(networkErrorVisibility: Boolean)
     fun loadURL(url: String)
 }
@@ -33,9 +33,9 @@ class AppWebPagePresenter(
             .subscribe(view::handleNetworkError)
             .addTo(compositeDisposable)
 
-        view.retryNetworkConnectionClicks.subscribe {
-            dispatcher.dispatch(NetworkAction.CheckConnectivity)
-        }?.addTo(compositeDisposable)
+//        view.retryNetworkConnectionClicks.subscribe {
+//            dispatcher.dispatch(NetworkAction.CheckConnectivity)
+//        }?.addTo(compositeDisposable)
 
         view.loadURL(url!!)
     }

--- a/app/src/main/java/mozilla/lockbox/presenter/AppWebPagePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppWebPagePresenter.kt
@@ -6,10 +6,8 @@
 
 package mozilla.lockbox.presenter
 
-import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.rxkotlin.addTo
-import mozilla.lockbox.action.NetworkAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
 import mozilla.lockbox.store.NetworkStore

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -13,7 +13,6 @@ import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.LifecycleAction
-import mozilla.lockbox.action.NetworkAction
 import mozilla.lockbox.action.OnboardingStatusAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -26,7 +26,7 @@ import mozilla.lockbox.support.Constant
 interface FxALoginView {
     var webViewRedirect: ((url: Uri?) -> Boolean)
     val skipFxAClicks: Observable<Unit>?
-    val retryNetworkConnectionClicks: Observable<Unit>
+//    val retryNetworkConnectionClicks: Observable<Unit>
     fun handleNetworkError(networkErrorVisibility: Boolean)
     fun loadURL(url: String)
 }
@@ -70,9 +70,9 @@ class FxALoginPresenter(
             .subscribe(view::handleNetworkError)
             .addTo(compositeDisposable)
 
-        view.retryNetworkConnectionClicks.subscribe {
-            dispatcher.dispatch(NetworkAction.CheckConnectivity)
-        }?.addTo(compositeDisposable)
+//        view.retryNetworkConnectionClicks.subscribe {
+//            dispatcher.dispatch(NetworkAction.CheckConnectivity)
+//        }?.addTo(compositeDisposable)
     }
 
     private fun triggerOnboarding() {

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -36,9 +36,8 @@ interface ItemDetailView {
     var isPasswordVisible: Boolean
     fun updateItem(item: ItemDetailViewModel)
     fun showToastNotification(@StringRes strId: Int)
-
-    val retryNetworkConnectionClicks: Observable<Unit>
     fun handleNetworkError(networkErrorVisibility: Boolean)
+    //    val retryNetworkConnectionClicks: Observable<Unit>
 }
 
 @ExperimentalCoroutinesApi
@@ -107,9 +106,9 @@ class ItemDetailPresenter(
             .subscribe { view.isPasswordVisible = it }
             .addTo(compositeDisposable)
 
-        view.retryNetworkConnectionClicks.subscribe {
-            dispatcher.dispatch(NetworkAction.CheckConnectivity)
-        }?.addTo(compositeDisposable)
+//        view.retryNetworkConnectionClicks.subscribe {
+//            dispatcher.dispatch(NetworkAction.CheckConnectivity)
+//        }?.addTo(compositeDisposable)
     }
 
     private fun handleClicks(clicks: Observable<Unit>, withServerPassword: (ServerPassword) -> Unit) {

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -16,7 +16,6 @@ import mozilla.lockbox.R
 import mozilla.lockbox.action.ClipboardAction
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.ItemDetailAction
-import mozilla.lockbox.action.NetworkAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.extensions.filterNotNull
 import mozilla.lockbox.extensions.toDetailViewModel

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -14,7 +14,6 @@ import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.action.DataStoreAction
-import mozilla.lockbox.action.NetworkAction
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.Setting
 import mozilla.lockbox.action.SettingAction

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemListPresenter.kt
@@ -44,7 +44,7 @@ interface ItemListView {
     fun updateItemListSort(sort: Setting.ItemListSort)
     fun loading(isLoading: Boolean)
     fun handleNetworkError(networkErrorVisibility: Boolean)
-    val retryNetworkConnectionClicks: Observable<Unit>
+//    val retryNetworkConnectionClicks: Observable<Unit>
     val refreshItemList: Observable<Unit>
     val isRefreshing: Boolean
     fun stopRefreshing()
@@ -157,9 +157,9 @@ class ItemListPresenter(
             .addTo(compositeDisposable)
 
         // TODO: make this more robust to retry loading the correct page again (loadUrl)
-        view.retryNetworkConnectionClicks.subscribe {
-            dispatcher.dispatch(NetworkAction.CheckConnectivity)
-        }?.addTo(compositeDisposable)
+//        view.retryNetworkConnectionClicks.subscribe {
+//            dispatcher.dispatch(NetworkAction.CheckConnectivity)
+//        }?.addTo(compositeDisposable)
     }
 
     private fun onMenuItem(@IdRes item: Int) {

--- a/app/src/main/java/mozilla/lockbox/view/AppWebPageFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/AppWebPageFragment.kt
@@ -16,11 +16,8 @@ import android.view.ViewGroup
 import mozilla.lockbox.R
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import com.jakewharton.rxbinding2.view.clicks
-import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_fxa_login.view.*
-import kotlinx.android.synthetic.main.fragment_warning.view.*
 import kotlinx.android.synthetic.main.fragment_webview.*
 import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.presenter.WebPageView

--- a/app/src/main/java/mozilla/lockbox/view/AppWebPageFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/AppWebPageFragment.kt
@@ -81,6 +81,6 @@ class AppWebPageFragment : BackableFragment(), WebPageView {
         }
     }
 
-    override val retryNetworkConnectionClicks: Observable<Unit>
-        get() = view!!.networkWarning.retryButton.clicks()
+//    override val retryNetworkConnectionClicks: Observable<Unit>
+//        get() = view!!.networkWarning.retryButton.clicks()
 }

--- a/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FxALoginFragment.kt
@@ -77,8 +77,8 @@ class FxALoginFragment : BackableFragment(), FxALoginView {
         }
     }
 
-    override val retryNetworkConnectionClicks: Observable<Unit>
-        get() = view!!.networkWarning.retryButton.clicks()
+//    override val retryNetworkConnectionClicks: Observable<Unit>
+//        get() = view!!.networkWarning.retryButton.clicks()
 
     override val skipFxAClicks: Observable<Unit>?
         get() = skipFxA?.clicks()

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -21,7 +21,6 @@ import com.jakewharton.rxbinding2.view.clicks
 import io.reactivex.Observable
 import kotlinx.android.synthetic.main.fragment_item_detail.*
 import kotlinx.android.synthetic.main.fragment_item_detail.view.*
-import kotlinx.android.synthetic.main.fragment_warning.view.*
 import kotlinx.android.synthetic.main.include_backable.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
@@ -130,8 +129,8 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         }
     }
 
-    override val retryNetworkConnectionClicks: Observable<Unit>
-        get() = view!!.networkWarning.retryButton.clicks()
+//    override val retryNetworkConnectionClicks: Observable<Unit>
+//        get() = view!!.networkWarning.retryButton.clicks()
 }
 
 var EditText.readOnly: Boolean

--- a/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemListFragment.kt
@@ -223,6 +223,6 @@ class ItemListFragment : Fragment(), ItemListView {
         }
     }
 
-    override val retryNetworkConnectionClicks: Observable<Unit>
-        get() = view!!.networkWarning.retryButton.clicks()
+//    override val retryNetworkConnectionClicks: Observable<Unit>
+//        get() = view!!.networkWarning.retryButton.clicks()
 }

--- a/app/src/main/res/layout/fragment_warning.xml
+++ b/app/src/main/res/layout/fragment_warning.xml
@@ -13,6 +13,7 @@
         android:theme="@style/NoConnectivityWarning"
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
+        android:visibility="gone"
         xmlns:tools="http://schemas.android.com/tools">
 
         <ImageView

--- a/app/src/main/res/layout/fragment_warning.xml
+++ b/app/src/main/res/layout/fragment_warning.xml
@@ -14,7 +14,8 @@
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
         android:visibility="gone"
-        xmlns:tools="http://schemas.android.com/tools">
+        xmlns:tools="http://schemas.android.com/tools"
+>
 
         <ImageView
                 android:layout_width="wrap_content"
@@ -33,7 +34,7 @@
                 android:id="@+id/warningMessage"
                 android:contentDescription="@string/networkWarningMessage"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="40dp"
                 android:background="@color/gray_73_percent"
                 android:letterSpacing="0.01"
                 android:layout_marginStart="4dp"
@@ -42,24 +43,23 @@
                 android:textStyle="normal"
                 android:textColor="@color/text_white"
                 android:lineSpacingExtra="6.5sp"
+                android:padding="10dp"
                 tools:text="@string/no_internet_connection"
                 app:layout_constraintStart_toEndOf="@id/warningIcon"
-                app:layout_constraintTop_toTopOf="@id/warningIcon"
-                app:layout_constraintBottom_toBottomOf="@id/warningIcon"
                 tools:ignore="SelectableText" />
-        <Button
-                android:id="@+id/retryButton"
-                android:contentDescription="@string/retryButton"
-                android:layout_width="40dp"
-                android:layout_height="wrap_content"
-                android:text="@string/retry"
-                android:textAllCaps="false"
-                android:background="@android:color/transparent"
-                android:textSize="13sp"
-                android:fontFamily="sans-serif"
-                android:textStyle="bold"
-                android:textColor="@color/text_white"
-                android:lineSpacingExtra="6.5sp"
-                app:layout_constraintEnd_toEndOf="parent" />
+        <!--<Button-->
+                <!--android:id="@+id/retryButton"-->
+                <!--android:contentDescription="@string/retryButton"-->
+                <!--android:layout_width="40dp"-->
+                <!--android:layout_height="wrap_content"-->
+                <!--android:text="@string/retry"-->
+                <!--android:textAllCaps="false"-->
+                <!--android:background="@android:color/transparent"-->
+                <!--android:textSize="13sp"-->
+                <!--android:fontFamily="sans-serif"-->
+                <!--android:textStyle="bold"-->
+                <!--android:textColor="@color/text_white"-->
+                <!--android:lineSpacingExtra="6.5sp"-->
+                <!--app:layout_constraintEnd_toEndOf="parent" />-->
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,5 +14,5 @@
     <dimen name="sort_item_padding">8dp</dimen>
     <dimen name="hidden_network_error">0px</dimen>
     <dimen name="network_error_with_toolbar">96dp</dimen>
-    <dimen name="network_error">46dp</dimen>
+    <dimen name="network_error">40dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,9 +192,9 @@
     <string name="password_for">Password for %1$s</string>
 
     <!-- This is the text displayed on the button of the network availability error message -->
-    <string name="retry">Retry</string>
+    <!--<string name="retry">Retry</string>-->
     <!-- This is the text displayed on the button of the network availability error message -->
-    <string name="retryButton">Retry connect to internet</string>
+    <!--<string name="retryButton">Retry connect to internet</string>-->
     <!-- This label is used by screenreaders to inform the user that their device is not connected to the internet -->
     <string name="networkWarningMessage">Warning: device not connected to the internet.</string>
     <!-- This label is used by screenreaders to inform the user that the message contains an image of a warning icon -->
@@ -249,7 +249,6 @@
     <string name="skip_button">Skip</string>
     <!-- This is the the button description on the device security dialog box which routes to system security settings. -->
     <string name="set_up_now">Set Up Now</string>
-
 
     <!-- This header appears above the Privacy page of the mozilla-lockbox website. -->
     <string name="privacy">Privacy</string>

--- a/app/src/test/java/mozilla/lockbox/presenter/AppWebPagePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AppWebPagePresenterTest.kt
@@ -25,9 +25,9 @@ class AppWebPagePresenterTest {
 
     class WebPageViewFake : WebPageView {
 
-        val retryButtonStub = PublishSubject.create<Unit>()
-        override val retryNetworkConnectionClicks: Observable<Unit>
-            get() = retryButtonStub
+//        val retryButtonStub = PublishSubject.create<Unit>()
+//        override val retryNetworkConnectionClicks: Observable<Unit>
+//            get() = retryButtonStub
 
         var networkAvailable = PublishSubject.create<Boolean>()
         override fun handleNetworkError(networkErrorVisibility: Boolean) {

--- a/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FxALoginPresenterTest.kt
@@ -46,9 +46,9 @@ class FxALoginPresenterTest : DisposingTest() {
         compositeDisposable: CompositeDisposable
     ) : FxALoginView {
 
-        private val retryButtonStub = PublishSubject.create<Unit>()
-        override val retryNetworkConnectionClicks: Observable<Unit>
-            get() = retryButtonStub
+//        private val retryButtonStub = PublishSubject.create<Unit>()
+//        override val retryNetworkConnectionClicks: Observable<Unit>
+//            get() = retryButtonStub
 
         var networkAvailable = PublishSubject.create<Boolean>()
         override fun handleNetworkError(networkErrorVisibility: Boolean) {

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -49,9 +49,9 @@ class ItemDetailPresenterTest {
         override val learnMoreClicks: Observable<Unit>
             get() = learnMoreClickStub
 
-        private val retryButtonStub = PublishSubject.create<Unit>()
-        override val retryNetworkConnectionClicks: Observable<Unit>
-            get() = retryButtonStub
+//        private val retryButtonStub = PublishSubject.create<Unit>()
+//        override val retryNetworkConnectionClicks: Observable<Unit>
+//            get() = retryButtonStub
 
         var networkAvailable = PublishSubject.create<Boolean>()
         override fun handleNetworkError(networkErrorVisibility: Boolean) {

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemListPresenterTest.kt
@@ -84,9 +84,9 @@ private val password3 = ServerPassword(
 open class ItemListPresenterTest {
     class FakeView : ItemListView {
 
-        private val retryButtonStub = PublishSubject.create<Unit>()
-        override val retryNetworkConnectionClicks: Observable<Unit>
-            get() = retryButtonStub
+//        private val retryButtonStub = PublishSubject.create<Unit>()
+//        override val retryNetworkConnectionClicks: Observable<Unit>
+//            get() = retryButtonStub
 
         var networkAvailable = PublishSubject.create<Boolean>()
         override fun handleNetworkError(networkErrorVisibility: Boolean) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext.kotlin_version = '1.3.0'
     ext.android_components_version = '0.40.0'
     ext.lifecycle_version = '1.1.1'
-    ext.navigation_version = '1.0.0-beta02'
+    ext.navigation_version = '1.0.0-rc01'
     ext.rxbinding_version = '2.2.0'
     ext.coroutine_version = '1.0.1'
     ext.androidxTest_version = '1.1.0'


### PR DESCRIPTION
Fixes #445 

## Testing and Review Notes
Warning message reference: https://app.zeplin.io/project/5b6895bfe4af825140aa8dbc/screen/5bdb23c0e6a1bc46944e0813

This PR also defaults the visibility to `GONE` so you shouldn't be able to see the flash of the network warning every time you navigate to a new screen.

## Screenshots or Videos

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)

