### PR TITLE
Remove non-appropriate onFailure calls in autofill service.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,5 +259,7 @@
     <string name="autofill_error_no_hostname">Unexpected hostname format</string>
     <!-- This is the prompt when autofill is triggered, Lockbox is unlocked, and no passwords are detected. -->
     <string name="autofill_search_cta">Search Firefox Lockbox</string>
+    <!-- This is the error message when autofill is triggered and Lockbox is in an error state. %s refers to the localized error message -->
+    <string name="autofill_error_toast">Firefox Lockbox encountered an error: %s</string>
 
 </resources>


### PR DESCRIPTION
Fix #379.

According to the [autofill docs][1], we should use `onFailure` if something goes wrong on our side, but not if we have no data.

My interpretation is that we should thus use `onSuccess(null)` over `onFailure` if we can't find any autofill ids (i.e. there is nothing to autofill).

[1]: https://developer.android.com/guide/topics/text/autofill-services#fill