### PR TITLE
Removing functions to set username copy ability, adding back to fragm…

### DIFF
--- a/app/src/main/java/mozilla/lockbox/model/ItemDetailViewModel.kt
+++ b/app/src/main/java/mozilla/lockbox/model/ItemDetailViewModel.kt
@@ -12,4 +12,7 @@ data class ItemDetailViewModel(
     val hostname: String,
     val username: String?,
     val password: String
-)
+) {
+    var hasUsername: Boolean = false
+        get() = !username.isNullOrBlank()
+}

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -34,11 +34,10 @@ interface ItemDetailView {
     val hostnameClicks: Observable<Unit>
     val learnMoreClicks: Observable<Unit>
     var isPasswordVisible: Boolean
-    fun updateItem(item: ItemDetailViewModel)
+    fun updateItem(item: ItemDetailViewModel, showUsernamePlaceholder: Boolean)
     fun showToastNotification(@StringRes strId: Int)
     fun handleNetworkError(networkErrorVisibility: Boolean)
     //    val retryNetworkConnectionClicks: Observable<Unit>
-    var showUsernamePlaceholder: Boolean
 }
 
 @ExperimentalCoroutinesApi
@@ -96,8 +95,8 @@ class ItemDetailPresenter(
             .doOnNext { credentials = it }
             .map { it.toDetailViewModel() }
             .subscribe {
-                view.showUsernamePlaceholder = it.username.isNullOrEmpty()
-                view.updateItem(it)
+                val showUsernamePlaceholder = it.username.isNullOrEmpty()
+                view.updateItem(it, showUsernamePlaceholder)
             }
             .addTo(compositeDisposable)
 

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -38,8 +38,7 @@ interface ItemDetailView {
     fun showToastNotification(@StringRes strId: Int)
     fun handleNetworkError(networkErrorVisibility: Boolean)
     //    val retryNetworkConnectionClicks: Observable<Unit>
-    fun showUsernamePlaceholder()
-    fun showUsername(username: String)
+    var showUsernamePlaceholder: Boolean
 }
 
 @ExperimentalCoroutinesApi
@@ -56,7 +55,7 @@ class ItemDetailPresenter(
 
     override fun onViewReady() {
         handleClicks(view.usernameCopyClicks) {
-            if (!it.username.isNullOrEmpty()) {
+            if (!it.username.isNullOrEmpty() && it.username != " ") {
                 dispatcher.dispatch(ClipboardAction.CopyUsername(it.username.toString()))
                 dispatcher.dispatch(DataStoreAction.Touch(it.id))
                 view.showToastNotification(R.string.toast_username_copied)
@@ -97,11 +96,7 @@ class ItemDetailPresenter(
             .doOnNext { credentials = it }
             .map { it.toDetailViewModel() }
             .subscribe {
-                if (it.username.isNullOrEmpty()) {
-                    view.showUsernamePlaceholder()
-                } else {
-                    view.showUsername(it.username)
-                }
+                view.showUsernamePlaceholder = it.username.isNullOrEmpty()
                 view.updateItem(it)
             }
             .addTo(compositeDisposable)

--- a/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/ItemDetailPresenter.kt
@@ -34,7 +34,7 @@ interface ItemDetailView {
     val hostnameClicks: Observable<Unit>
     val learnMoreClicks: Observable<Unit>
     var isPasswordVisible: Boolean
-    fun updateItem(item: ItemDetailViewModel, showUsernamePlaceholder: Boolean)
+    fun updateItem(item: ItemDetailViewModel)
     fun showToastNotification(@StringRes strId: Int)
     fun handleNetworkError(networkErrorVisibility: Boolean)
     //    val retryNetworkConnectionClicks: Observable<Unit>
@@ -54,7 +54,7 @@ class ItemDetailPresenter(
 
     override fun onViewReady() {
         handleClicks(view.usernameCopyClicks) {
-            if (!it.username.isNullOrEmpty() && it.username != " ") {
+            if (!it.username.isNullOrBlank()) {
                 dispatcher.dispatch(ClipboardAction.CopyUsername(it.username.toString()))
                 dispatcher.dispatch(DataStoreAction.Touch(it.id))
                 view.showToastNotification(R.string.toast_username_copied)
@@ -94,10 +94,7 @@ class ItemDetailPresenter(
             .filterNotNull()
             .doOnNext { credentials = it }
             .map { it.toDetailViewModel() }
-            .subscribe {
-                val showUsernamePlaceholder = it.username.isNullOrEmpty()
-                view.updateItem(it, showUsernamePlaceholder)
-            }
+            .subscribe(view::updateItem)
             .addTo(compositeDisposable)
 
         networkStore.isConnected
@@ -115,8 +112,8 @@ class ItemDetailPresenter(
 
     private fun handleClicks(clicks: Observable<Unit>, withServerPassword: (ServerPassword) -> Unit) {
         clicks.subscribe {
-            this.credentials?.let { password -> withServerPassword(password) }
-        }
+                this.credentials?.let { password -> withServerPassword(password) }
+            }
             .addTo(compositeDisposable)
     }
 }

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -47,8 +47,6 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
 
     private val errorHelper = NetworkErrorHelper()
 
-    override var showUsernamePlaceholder: Boolean = false
-
     override val usernameCopyClicks: Observable<Unit>
         get() = view!!.inputUsername.clicks()
 
@@ -81,7 +79,7 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         }
     }
 
-    override fun updateItem(item: ItemDetailViewModel) {
+    override fun updateItem(item: ItemDetailViewModel, showUsernamePlaceholder: Boolean) {
         assertOnUiThread()
         toolbar.title = item.title
 
@@ -90,18 +88,16 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputLayoutPassword.isHintAnimationEnabled = false
 
         inputUsername.readOnly = true
-        when (showUsernamePlaceholder) {
-            true -> {
-                view!!.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
-                view!!.isClickable = false
-                view!!.isFocusable = false
-                inputUsername.setText(" ", TextView.BufferType.NORMAL)
-            }
-            false -> {
-                inputUsername.isClickable = true
-                inputUsername.isFocusable = true
-                inputUsername.setText(item.username, TextView.BufferType.NORMAL)
-            }
+
+        if (showUsernamePlaceholder) {
+            view!!.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
+            view!!.isClickable = false
+            view!!.isFocusable = false
+            inputUsername.setText(getString(R.string.empty_space), TextView.BufferType.NORMAL)
+        } else {
+            inputUsername.isClickable = true
+            inputUsername.isFocusable = true
+            inputUsername.setText(item.username, TextView.BufferType.NORMAL)
         }
 
         inputPassword.readOnly = true

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -31,9 +31,6 @@ import mozilla.lockbox.support.assertOnUiThread
 
 @ExperimentalCoroutinesApi
 class ItemDetailFragment : BackableFragment(), ItemDetailView {
-
-    private val errorHelper = NetworkErrorHelper()
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -47,6 +44,10 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         presenter = ItemDetailPresenter(this, itemId)
         return inflater.inflate(R.layout.fragment_item_detail, container, false)
     }
+
+    private val errorHelper = NetworkErrorHelper()
+
+    override var showUsernamePlaceholder: Boolean = false
 
     override val usernameCopyClicks: Observable<Unit>
         get() = view!!.inputUsername.clicks()
@@ -80,19 +81,6 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         }
     }
 
-    override fun showUsernamePlaceholder() {
-        view!!.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
-        view!!.isClickable = false
-        view!!.isFocusable = false
-        inputUsername.setText(" ", TextView.BufferType.NORMAL)
-    }
-
-    override fun showUsername(username: String) {
-        inputUsername.isClickable = true
-        inputUsername.isFocusable = true
-        inputUsername.setText(username, TextView.BufferType.NORMAL)
-    }
-
     override fun updateItem(item: ItemDetailViewModel) {
         assertOnUiThread()
         toolbar.title = item.title
@@ -102,6 +90,20 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputLayoutPassword.isHintAnimationEnabled = false
 
         inputUsername.readOnly = true
+        when (showUsernamePlaceholder) {
+            true -> {
+                view!!.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
+                view!!.isClickable = false
+                view!!.isFocusable = false
+                inputUsername.setText(" ", TextView.BufferType.NORMAL)
+            }
+            false -> {
+                inputUsername.isClickable = true
+                inputUsername.isFocusable = true
+                inputUsername.setText(item.username, TextView.BufferType.NORMAL)
+            }
+        }
+
         inputPassword.readOnly = true
         inputPassword.isClickable = true
         inputPassword.isFocusable = true

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -90,10 +90,10 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputUsername.readOnly = true
 
         if (showUsernamePlaceholder) {
-            view!!.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
-            view!!.isClickable = false
-            view!!.isFocusable = false
-            inputUsername.setText(getString(R.string.empty_space), TextView.BufferType.NORMAL)
+            inputUsername.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
+            inputUsername.isClickable = false
+            inputUsername.isFocusable = false
+            inputUsername.setText(R.string.empty_space, TextView.BufferType.NORMAL)
         } else {
             inputUsername.isClickable = true
             inputUsername.isFocusable = true

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -79,7 +79,7 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         }
     }
 
-    override fun updateItem(item: ItemDetailViewModel, showUsernamePlaceholder: Boolean) {
+    override fun updateItem(item: ItemDetailViewModel) {
         assertOnUiThread()
         toolbar.title = item.title
 
@@ -89,7 +89,7 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
 
         inputUsername.readOnly = true
 
-        if (showUsernamePlaceholder) {
+        if (!item.hasUsername) {
             inputUsername.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
             inputUsername.isClickable = false
             inputUsername.isFocusable = false

--- a/app/src/main/res/values/non_localizable_strings.xml
+++ b/app/src/main/res/values/non_localizable_strings.xml
@@ -10,6 +10,8 @@
     <string name="default_avatar_url"  translatable="false">https://firefoxusercontent.com/00000000000000000000000000000000</string>
     <!--suppress CheckTagEmptyBody -->
     <string name="empty_string"></string>
+    <!-- Unicode character for an empty space -->
+    <string name="empty_space">\u0020</string>
     <string name="firefox_account" translatable="false">Firefox Account</string>
     <string name="telemetry_server_endpoint" translatable="false">https://incoming.telemetry.mozilla.org</string>
 </resources>

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -48,15 +48,7 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class ItemDetailPresenterTest {
     class FakeView : ItemDetailView {
-        var isShowUsernamePlaceholderCalled = false
-        override fun showUsernamePlaceholder() {
-            isShowUsernamePlaceholderCalled = true
-        }
-
-        var isShowUsernameCalled = false
-        override fun showUsername(username: String) {
-            isShowUsernameCalled = true
-        }
+        override var showUsernamePlaceholder: Boolean = false
 
         val learnMoreClickStub = PublishSubject.create<Unit>()
         override val learnMoreClicks: Observable<Unit>
@@ -199,17 +191,13 @@ class ItemDetailPresenterTest {
     @Test
     fun `correct formatting functions called with null username`() {
         setUpTestSubject(fakeCredentialNoUsername.asOptional())
-
-        assertEquals(true, view.isShowUsernamePlaceholderCalled)
-        assertEquals(false, view.isShowUsernameCalled)
+        assertEquals(true, view.showUsernamePlaceholder)
     }
 
     @Test
     fun `correct formatting functions called with non-null username`() {
         setUpTestSubject(fakeCredential.asOptional())
-
-        assertEquals(false, view.isShowUsernamePlaceholderCalled)
-        assertEquals(true, view.isShowUsernameCalled)
+        assertEquals(false, view.showUsernamePlaceholder)
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -48,7 +48,6 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class ItemDetailPresenterTest {
     class FakeView : ItemDetailView {
-        override var showUsernamePlaceholder: Boolean = false
 
         val learnMoreClickStub = PublishSubject.create<Unit>()
         override val learnMoreClicks: Observable<Unit>
@@ -74,10 +73,11 @@ class ItemDetailPresenterTest {
 
         override var isPasswordVisible: Boolean = false
 
-        override fun updateItem(item: ItemDetailViewModel) {
+        var showPlaceholderUsernameStub: Boolean = false
+        override fun updateItem(item: ItemDetailViewModel, showPlaceholderUsername: Boolean) {
             this.item = item
+            showPlaceholderUsernameStub = showPlaceholderUsername
         }
-
         override fun showToastNotification(@StringRes strId: Int) {
             toastNotificationArgument = strId
         }
@@ -176,7 +176,7 @@ class ItemDetailPresenterTest {
                 fakeCredentialNoUsername.hostname,
                 fakeCredentialNoUsername.username,
                 fakeCredentialNoUsername.password
-            )
+            ), true
         )
 
         Assert.assertEquals(fakeCredentialNoUsername.id, dataStore.idArg)
@@ -191,13 +191,13 @@ class ItemDetailPresenterTest {
     @Test
     fun `correct formatting functions called with null username`() {
         setUpTestSubject(fakeCredentialNoUsername.asOptional())
-        assertEquals(true, view.showUsernamePlaceholder)
+        assertEquals(true, view.showPlaceholderUsernameStub)
     }
 
     @Test
     fun `correct formatting functions called with non-null username`() {
         setUpTestSubject(fakeCredential.asOptional())
-        assertEquals(false, view.showUsernamePlaceholder)
+        assertEquals(false, view.showPlaceholderUsernameStub)
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -74,9 +74,9 @@ class ItemDetailPresenterTest {
         override var isPasswordVisible: Boolean = false
 
         var showPlaceholderUsernameStub: Boolean = false
-        override fun updateItem(item: ItemDetailViewModel, showPlaceholderUsername: Boolean) {
+        override fun updateItem(item: ItemDetailViewModel) {
             this.item = item
-            showPlaceholderUsernameStub = showPlaceholderUsername
+            showPlaceholderUsernameStub = !item.hasUsername
         }
         override fun showToastNotification(@StringRes strId: Int) {
             toastNotificationArgument = strId
@@ -176,8 +176,7 @@ class ItemDetailPresenterTest {
                 fakeCredentialNoUsername.hostname,
                 fakeCredentialNoUsername.username,
                 fakeCredentialNoUsername.password
-            ),
-            true
+            )
         )
 
         Assert.assertEquals(fakeCredentialNoUsername.id, dataStore.idArg)

--- a/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/ItemDetailPresenterTest.kt
@@ -176,7 +176,8 @@ class ItemDetailPresenterTest {
                 fakeCredentialNoUsername.hostname,
                 fakeCredentialNoUsername.username,
                 fakeCredentialNoUsername.password
-            ), true
+            ),
+            true
         )
 
         Assert.assertEquals(fakeCredentialNoUsername.id, dataStore.idArg)


### PR DESCRIPTION
…ent.

Fixes username copy

## Testing and Review Notes
Breaking out the `showUsernamePlaceholder()`/`showUsername()` into functions that are called from the presenter was preventing the fragment from setting the click and focus correctly. This was preventing the user from successfully copying their username. 

Removed code, replaced with a flag (`showUsernamePlaceholder`) that is being set in the presenter to be used in the `updateItem()` function: 
```
    override fun showUsernamePlaceholder() {
        view!!.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
        view!!.isClickable = false
        view!!.isFocusable = false
        inputUsername.setText(" ", TextView.BufferType.NORMAL)
    }

    override fun showUsername(username: String) {
        inputUsername.isClickable = true
        inputUsername.isFocusable = true
        inputUsername.setText(username, TextView.BufferType.NORMAL)
    }
```


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
