### PR TITLE
Suppress browser chooser after backing out of OpenWebsite action.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -28,6 +28,7 @@ open class RouteAction(
     data class ItemDetail(val id: String) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.entry_detail)
     data class OpenWebsite(val url: String) :
         RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.open_in_browser)
+    object PostOpenWebsite : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.open_in_browser)
 
     data class SystemSetting(val setting: SettingIntent) :
         RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_system)

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -28,7 +28,11 @@ open class RouteAction(
     data class ItemDetail(val id: String) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.entry_detail)
     data class OpenWebsite(val url: String) :
         RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.open_in_browser)
-    object PostOpenWebsite : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.open_in_browser)
+
+    // This route shouldn't be used on its own. It is a terminator route to ensure that actions
+    // that leave the app do not get replayed once the app becomes foregrounded.
+    // It never flows through the dispatcher, so does not get wrongly recorded by telemetry.
+    object NoFollowOnReturn : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
 
     data class SystemSetting(val setting: SettingIntent) :
         RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_system)

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -41,10 +41,11 @@ open class RouteStore(
         dispatcher.register
             .filterByType(RouteAction::class.java)
             .flatMap {
-                if (it is RouteAction.OpenWebsite) {
-                    Observable.just(it, RouteAction.PostOpenWebsite)
-                } else {
-                    Observable.just(it)
+                when (it) {
+                    is RouteAction.OpenWebsite,
+                    is RouteAction.SystemSetting ->
+                            Observable.just(it, RouteAction.NoFollowOnReturn)
+                    else -> Observable.just(it)
                 }
             }
             .subscribe(_routes)

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -40,6 +40,13 @@ open class RouteStore(
     init {
         dispatcher.register
             .filterByType(RouteAction::class.java)
+            .flatMap {
+                if (it is RouteAction.OpenWebsite) {
+                    Observable.just(it, RouteAction.PostOpenWebsite)
+                } else {
+                    Observable.just(it)
+                }
+            }
             .subscribe(_routes)
 
         dispatcher.register

--- a/app/src/test/java/mozilla/lockbox/store/RouteStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/RouteStoreTest.kt
@@ -11,6 +11,8 @@ import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.action.SettingIntent
+import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import org.junit.Before
@@ -39,6 +41,18 @@ class RouteStoreTest {
         dispatcher.dispatch(action)
 
         routeObserver.assertValue(action)
+    }
+
+    @Test
+    fun `dispatched route actions with no follow actions`() {
+        dispatcher.dispatch(RouteAction.ItemList)
+        routeObserver.assertLastValue(RouteAction.ItemList)
+
+        dispatcher.dispatch(RouteAction.SystemSetting(SettingIntent.Security))
+        routeObserver.assertLastValue(RouteAction.NoFollowOnReturn)
+
+        dispatcher.dispatch(RouteAction.OpenWebsite("https://mozilla.org"))
+        routeObserver.assertLastValue(RouteAction.NoFollowOnReturn)
     }
 
     @Test


### PR DESCRIPTION
Fixes #460

When the back button is pressed it has no effect on the `RouteStore.routes`; when the user relaunches the app, the route presenter resubscribes, and gets the replayed `OpenWebsite` route, so re-presents the Browser chooser dialog.