### PR TITLE
Fixup no-username bugs (crash and string change)

### DIFF
--- a/app/src/main/java/mozilla/lockbox/autofill/FillResponseBuilder.kt
+++ b/app/src/main/java/mozilla/lockbox/autofill/FillResponseBuilder.kt
@@ -97,17 +97,18 @@ open class FillResponseBuilder(
         val datasetBuilder = Dataset.Builder()
 
         val title = titleFromHostname(credential.hostname)
+        val username = credential.username ?: context.getString(R.string.no_username)
 
         parsedStructure.usernameId?.let {
             val presentation = RemoteViews(context.packageName, R.layout.autofill_item)
                 .apply {
-                    setTextViewText(R.id.autofillValue, credential.username)
+                    setTextViewText(R.id.autofillValue, username)
                     setTextViewText(R.id.hostname, title)
                 }
 
             datasetBuilder.setValue(
                 it,
-                AutofillValue.forText(credential.username),
+                AutofillValue.forText(credential.username ?: ""),
                 presentation
             )
         }
@@ -115,7 +116,7 @@ open class FillResponseBuilder(
         parsedStructure.passwordId?.let {
             val presentation = RemoteViews(context.packageName, R.layout.autofill_item)
                 .apply {
-                    setTextViewText(R.id.autofillValue, context.getString(R.string.password_for, credential.username))
+                    setTextViewText(R.id.autofillValue, context.getString(R.string.password_for, username))
                     setTextViewText(R.id.hostname, title)
                 }
 

--- a/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/ItemDetailFragment.kt
@@ -90,11 +90,12 @@ class ItemDetailFragment : BackableFragment(), ItemDetailView {
         inputUsername.readOnly = true
 
         if (!item.hasUsername) {
-            inputUsername.btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent))
+            btnUsernameCopy.setColorFilter(resources.getColor(R.color.white_60_percent, null))
             inputUsername.isClickable = false
             inputUsername.isFocusable = false
             inputUsername.setText(R.string.empty_space, TextView.BufferType.NORMAL)
         } else {
+            btnUsernameCopy.clearColorFilter()
             inputUsername.isClickable = true
             inputUsername.isFocusable = true
             inputUsername.setText(item.username, TextView.BufferType.NORMAL)


### PR DESCRIPTION
Fixes #488.

This PR fixes a crash caused by `kotlinx.android` auto generated code being incorrectly generated and incorrectly used. This PR does not address the generated code, which allowed: 

```kotlin
inputUsername.btnUsernameCopy
```

to be used, which resolves to `null`.

It also addresses an issue in autofill which caused strings containing "null" in display strings for autofill.