### PR TITLE
Navigation/Rx sanity.

### DIFF
--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -29,10 +29,8 @@ open class RouteAction(
     data class OpenWebsite(val url: String) :
         RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.open_in_browser)
 
-    // This route shouldn't be used on its own. It is a terminator route to ensure that actions
-    // that leave the app do not get replayed once the app becomes foregrounded.
-    // It never flows through the dispatcher, so does not get wrongly recorded by telemetry.
-    object NoFollowOnReturn : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
+    // This should _only_ be triggered by pressing the back button.
+    object InternalBack : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
 
     data class SystemSetting(val setting: SettingIntent) :
         RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_system)

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -12,6 +12,7 @@ import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import mozilla.lockbox.R
 import mozilla.lockbox.flux.Action
+import mozilla.lockbox.support.Constant
 
 open class RouteAction(
     override val eventMethod: TelemetryEventMethod,
@@ -26,14 +27,10 @@ open class RouteAction(
     object LockScreen : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.lock_screen)
     object Filter : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.filter)
     data class ItemDetail(val id: String) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.entry_detail)
-    data class OpenWebsite(val url: String) :
-        RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.open_in_browser)
+
 
     // This should _only_ be triggered by pressing the back button.
     object InternalBack : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
-
-    data class SystemSetting(val setting: SettingIntent) :
-        RouteAction(TelemetryEventMethod.show, TelemetryEventObject.settings_system)
 
     sealed class DialogFragment(
         @StringRes val dialogTitle: Int,
@@ -45,6 +42,12 @@ open class RouteAction(
         object AutofillSearchDialog : DialogFragment(R.string.autofill)
     }
 
+    open class SystemIntent(
+        val requestCode: Int = Constant.RequestCode.noResult,
+        eventMethod: TelemetryEventMethod,
+        eventObject: TelemetryEventObject
+    ) : RouteAction(eventMethod, eventObject)
+
     sealed class Onboarding(
         eventObject: TelemetryEventObject
     ) : RouteAction(TelemetryEventMethod.show, eventObject) {
@@ -52,6 +55,24 @@ open class RouteAction(
         object Autofill : Onboarding(TelemetryEventObject.onboarding_autofill)
         object Confirmation : Onboarding(TelemetryEventObject.login_onboarding_confirmation)
     }
+
+    object UnlockFallbackDialog : SystemIntent(
+        Constant.RequestCode.unlock,
+        TelemetryEventMethod.show,
+        TelemetryEventObject.dialog
+    )
+
+    data class OpenWebsite(val url: String) : SystemIntent(
+        Constant.RequestCode.noResult,
+        TelemetryEventMethod.tap,
+        TelemetryEventObject.open_in_browser
+    )
+
+    data class SystemSetting(val setting: SettingIntent) : SystemIntent(
+        Constant.RequestCode.noResult,
+        TelemetryEventMethod.show,
+        TelemetryEventObject.settings_system
+    )
 }
 
 data class OnboardingStatusAction(val onboardingInProgress: Boolean) : Action

--- a/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/RouteAction.kt
@@ -28,7 +28,6 @@ open class RouteAction(
     object Filter : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.filter)
     data class ItemDetail(val id: String) : RouteAction(TelemetryEventMethod.show, TelemetryEventObject.entry_detail)
 
-
     // This should _only_ be triggered by pressing the back button.
     object InternalBack : RouteAction(TelemetryEventMethod.tap, TelemetryEventObject.back)
 

--- a/app/src/main/java/mozilla/lockbox/flux/StackReplaySubject.kt
+++ b/app/src/main/java/mozilla/lockbox/flux/StackReplaySubject.kt
@@ -197,8 +197,12 @@ internal constructor() : Subject<T>() {
     }
 
     fun trim(vararg values: T) {
+        trim { values.contains(it) }
+    }
+
+    fun trim(test: (T) -> Boolean) {
         synchronized(history) {
-            while (history.isNotEmpty() && values.contains(history.peek())) {
+            while (history.isNotEmpty() && test(history.peek())) {
                 history.pop()
             }
         }

--- a/app/src/main/java/mozilla/lockbox/flux/StackReplaySubject.kt
+++ b/app/src/main/java/mozilla/lockbox/flux/StackReplaySubject.kt
@@ -1,0 +1,286 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.flux
+
+import io.reactivex.Observer
+import io.reactivex.annotations.CheckReturnValue
+import io.reactivex.annotations.NonNull
+import io.reactivex.annotations.Nullable
+import io.reactivex.disposables.Disposable
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.subjects.Subject
+import java.util.Stack
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A ReplaySubject that emits the top most item on subscription.
+ *
+ * It also contains methods that manipulate the stack, but these do not affect any subscribed observers.
+ *
+ * For provenance, this was largely derived from PublishSubject, converted to Kotlin and a history stack added.
+ */
+class StackReplaySubject<T>
+internal constructor() : Subject<T>() {
+
+    /** The array of currently subscribed subscribers.  */
+    private val subscribers: AtomicReference<Array<StackDisposable<T>>>
+
+    /** The error, write before terminating and read after checking subscribers.  */
+    internal var error: Throwable? = null
+
+    private val history = Stack<T>()
+
+    /** The terminated indicator for the subscribers array.  */
+    private val terminated = emptyArray<StackDisposable<T>>()
+    /** An empty subscribers array to avoid allocating it all the time.  */
+    private val empty = emptyArray<StackDisposable<T>>()
+
+    init {
+        subscribers = AtomicReference(empty)
+    }
+
+    override fun subscribeActual(t: Observer<in T>) {
+        val ps = StackDisposable(t, this)
+        t.onSubscribe(ps)
+        if (add(ps)) {
+            // if cancellation happened while a successful add, the remove() didn't work
+            // so we need to do it again
+            if (ps.isDisposed) {
+                remove(ps)
+            } else {
+                replay(ps)
+            }
+        } else {
+            val ex = error
+            if (ex != null) {
+                t.onError(ex)
+            } else {
+                t.onComplete()
+            }
+        }
+    }
+
+    /**
+     * Tries to add the given subscriber to the subscribers array atomically
+     * or returns false if the subject has terminated.
+     * @param ps the subscriber to add
+     * @return true if successful, false if the subject has terminated
+     */
+    internal fun add(ps: StackDisposable<T>): Boolean {
+        while (true) {
+            val a = subscribers.get()
+            if (a === terminated) {
+                return false
+            }
+
+            val b = a + arrayOf(ps)
+
+            if (subscribers.compareAndSet(a, b)) {
+                return true
+            }
+        }
+    }
+
+    /**
+     * Atomically removes the given subscriber if it is subscribed to the subject.
+     * @param ps the subject to remove
+     */
+    internal fun remove(ps: StackDisposable<T>) {
+        while (true) {
+            val a = subscribers.get()
+            if (a === terminated || a === empty) {
+                return
+            }
+
+            val c = a.filterNot { it === ps }.toTypedArray()
+            if (subscribers.compareAndSet(a, if (c.isNotEmpty()) c else empty)) {
+                return
+            }
+        }
+    }
+
+    override fun onSubscribe(d: Disposable) {
+        if (subscribers.get() === terminated) {
+            d.dispose()
+        }
+    }
+
+    override fun onNext(t: T) {
+        synchronized(history) {
+            history.push(t)
+        }
+        for (pd in subscribers.get()) {
+            pd.onNext(t)
+        }
+    }
+
+    override fun onError(t: Throwable) {
+        if (subscribers.get() === terminated) {
+            RxJavaPlugins.onError(t)
+            return
+        }
+        error = t
+
+        for (pd in subscribers.getAndSet(terminated)) {
+            pd.onError(t)
+        }
+    }
+
+    override fun onComplete() {
+        if (subscribers.get() === terminated) {
+            return
+        }
+        for (pd in subscribers.getAndSet(terminated)) {
+            pd.onComplete()
+        }
+    }
+
+    override fun hasObservers(): Boolean {
+        return subscribers.get().isNotEmpty()
+    }
+
+    @Nullable
+    override fun getThrowable(): Throwable? {
+        return if (subscribers.get() === terminated) {
+            error
+        } else {
+            null
+        }
+    }
+
+    override fun hasThrowable(): Boolean {
+        return subscribers.get() === terminated && error != null
+    }
+
+    override fun hasComplete(): Boolean {
+        return subscribers.get() === terminated && error == null
+    }
+
+    /**
+     * Replay the item on the top of the stack currently.
+     */
+    private fun replay(ps: StackDisposable<T>) {
+        val item: T?
+        synchronized(history) {
+            item = if (history.isNotEmpty()) {
+                history.peek()
+            } else {
+                null
+            }
+        }
+        if (item != null) {
+            ps.onNext(item)
+        }
+    }
+
+    // Some utility methods to manipulate the stack.
+
+    fun getValue() = synchronized(history) { if (history.isNotEmpty()) { history.peek() } else { null } }
+
+    fun pop() = synchronized(history) { if (history.isNotEmpty()) { history.pop() } else { null } }
+
+    /**
+     * Only pop if the history will not empty after the pop.
+     */
+    fun safePop() {
+        synchronized(history) {
+            if (history.size > 1) {
+                history.pop()
+                assert(history.isNotEmpty())
+            }
+        }
+    }
+
+    fun trim(vararg values: T) {
+        synchronized(history) {
+            while (history.isNotEmpty() && values.contains(history.peek())) {
+                history.pop()
+            }
+        }
+    }
+
+    fun clear() = synchronized(history) { history.clear() }
+
+    /**
+     * Clear the history, except for the last thing added.
+     */
+    fun trimTail() {
+        synchronized(history) {
+            if (history.size <= 1) {
+                return
+            }
+            val head = history.peek()
+            history.clear()
+            history.push(head)
+        }
+    }
+
+    fun getSize() = synchronized(history) { history.size }
+
+    /**
+     * Wraps the actual subscriber, tracks its requests and makes cancellation
+     * to remove itself from the current subscribers array.
+     *
+     * @param <T> the value type
+    </T> */
+    internal class StackDisposable<T>
+    /**
+     * Constructs a PublishSubscriber, wraps the actual subscriber and the state.
+     * @param actual the actual subscriber
+     * @param parent the parent PublishProcessor
+     */(
+         /** The actual subscriber.  */
+         val downstream: Observer<in T>,
+         /** The subject state.  */
+         val parent: StackReplaySubject<T>
+     ) : AtomicBoolean(), Disposable {
+
+        fun onNext(t: T) {
+            if (!get()) {
+                downstream.onNext(t)
+            }
+        }
+
+        fun onError(t: Throwable) {
+            if (get()) {
+                RxJavaPlugins.onError(t)
+            } else {
+                downstream.onError(t)
+            }
+        }
+
+        fun onComplete() {
+            if (!get()) {
+                downstream.onComplete()
+            }
+        }
+
+        override fun dispose() {
+            if (compareAndSet(false, true)) {
+                parent.remove(this)
+            }
+        }
+
+        override fun isDisposed(): Boolean {
+            return get()
+        }
+    }
+
+    companion object {
+        /**
+         * Constructs a StackReplaySubject.
+         * @param <T> the value type
+         * @return the new StackReplaySubject
+        </T> */
+        @CheckReturnValue
+        @NonNull
+        fun <T> create(): StackReplaySubject<T> {
+            return StackReplaySubject()
+        }
+    }
+}

--- a/app/src/main/java/mozilla/lockbox/presenter/BackablePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/BackablePresenter.kt
@@ -1,5 +1,6 @@
 package mozilla.lockbox.presenter
 
+import androidx.annotation.CallSuper
 import io.reactivex.Observable
 import io.reactivex.rxkotlin.addTo
 import mozilla.lockbox.action.RouteAction
@@ -14,6 +15,7 @@ class BackablePresenter(
     val view: BackableView,
     val dispatcher: Dispatcher = Dispatcher.shared
 ) : Presenter() {
+    @CallSuper
     override fun onViewReady() {
         view.backButtonClicks
             .subscribe {

--- a/app/src/main/java/mozilla/lockbox/presenter/BackablePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/BackablePresenter.kt
@@ -1,15 +1,24 @@
 package mozilla.lockbox.presenter
 
+import io.reactivex.Observable
+import io.reactivex.rxkotlin.addTo
+import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
 
 interface BackableView {
-    // No methods yet.
+    val backButtonClicks: Observable<Unit>
 }
 
 class BackablePresenter(
     val view: BackableView,
     val dispatcher: Dispatcher = Dispatcher.shared
 ) : Presenter() {
-    // No methods yet.
+    override fun onViewReady() {
+        view.backButtonClicks
+            .subscribe {
+                dispatcher.dispatch(RouteAction.InternalBack)
+            }
+            .addTo(compositeDisposable)
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
@@ -86,6 +86,7 @@ class LockedPresenter(
 
     private fun unlockFallback() {
         if (fingerprintStore.isKeyguardDeviceSecure) {
+            dispatcher.dispatch(RouteAction.UnlockFallbackDialog)
             view.unlockFallback()
         } else {
             unlock()

--- a/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/LockedPresenter.kt
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit
 
 interface LockedView {
     val unlockButtonTaps: Observable<Unit>
-    fun unlockFallback()
     val unlockConfirmed: Observable<Boolean>
 }
 
@@ -87,7 +86,6 @@ class LockedPresenter(
     private fun unlockFallback() {
         if (fingerprintStore.isKeyguardDeviceSecure) {
             dispatcher.dispatch(RouteAction.UnlockFallbackDialog)
-            view.unlockFallback()
         } else {
             unlock()
         }

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -194,47 +194,47 @@ class RoutePresenter(
         // This maps two nodes in the graph_main.xml to the edge between them.
         // If a RouteAction is called from a place the graph doesn't know about then
         // the app will log.error.
-        return when (Pair(from, to)) {
-            Pair(R.id.fragment_null, R.id.fragment_item_list) -> R.id.action_init_to_unlocked
-            Pair(R.id.fragment_null, R.id.fragment_locked) -> R.id.action_init_to_locked
-            Pair(R.id.fragment_null, R.id.fragment_welcome) -> R.id.action_init_to_unprepared
+        return when (from to to) {
+            R.id.fragment_null to R.id.fragment_item_list -> R.id.action_init_to_unlocked
+            R.id.fragment_null to R.id.fragment_locked -> R.id.action_init_to_locked
+            R.id.fragment_null to R.id.fragment_welcome -> R.id.action_init_to_unprepared
 
-            Pair(R.id.fragment_welcome, R.id.fragment_fxa_login) -> R.id.action_welcome_to_fxaLogin
+            R.id.fragment_welcome to R.id.fragment_fxa_login -> R.id.action_welcome_to_fxaLogin
 
-            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
-            Pair(R.id.fragment_fxa_login, R.id.fragment_fingerprint_onboarding) ->
+            R.id.fragment_fxa_login to R.id.fragment_item_list -> R.id.action_fxaLogin_to_itemList
+            R.id.fragment_fxa_login to R.id.fragment_fingerprint_onboarding ->
                 R.id.action_fxaLogin_to_fingerprint_onboarding
-            Pair(R.id.fragment_fxa_login, R.id.fragment_onboarding_confirmation) ->
+            R.id.fragment_fxa_login to R.id.fragment_onboarding_confirmation ->
                 R.id.action_fxaLogin_to_onboarding_confirmation
 
-            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_onboarding_confirmation) ->
+            R.id.fragment_fingerprint_onboarding to R.id.fragment_onboarding_confirmation ->
                 R.id.action_fingerprint_onboarding_to_confirmation
-            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_autofill_onboarding) ->
+            R.id.fragment_fingerprint_onboarding to R.id.fragment_autofill_onboarding ->
                 R.id.action_onboarding_fingerprint_to_autofill
 
-            Pair(R.id.fragment_autofill_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_autofill_onboarding, R.id.fragment_onboarding_confirmation) -> R.id.action_autofill_onboarding_to_confirmation
+            R.id.fragment_autofill_onboarding to R.id.fragment_item_list -> R.id.action_to_itemList
+            R.id.fragment_autofill_onboarding to R.id.fragment_onboarding_confirmation -> R.id.action_autofill_onboarding_to_confirmation
 
-            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_to_webview
+            R.id.fragment_onboarding_confirmation to R.id.fragment_item_list -> R.id.action_to_itemList
+            R.id.fragment_onboarding_confirmation to R.id.fragment_webview -> R.id.action_to_webview
 
-            Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_locked, R.id.fragment_welcome) -> R.id.action_locked_to_welcome
+            R.id.fragment_locked to R.id.fragment_item_list -> R.id.action_to_itemList
+            R.id.fragment_locked to R.id.fragment_welcome -> R.id.action_locked_to_welcome
 
-            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> R.id.action_itemList_to_itemDetail
-            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> R.id.action_itemList_to_setting
-            Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> R.id.action_itemList_to_accountSetting
-            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_to_locked
-            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
-            Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_to_webview
+            R.id.fragment_item_list to R.id.fragment_item_detail -> R.id.action_itemList_to_itemDetail
+            R.id.fragment_item_list to R.id.fragment_setting -> R.id.action_itemList_to_setting
+            R.id.fragment_item_list to R.id.fragment_account_setting -> R.id.action_itemList_to_accountSetting
+            R.id.fragment_item_list to R.id.fragment_locked -> R.id.action_to_locked
+            R.id.fragment_item_list to R.id.fragment_filter -> R.id.action_itemList_to_filter
+            R.id.fragment_item_list to R.id.fragment_webview -> R.id.action_to_webview
 
-            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_to_webview
+            R.id.fragment_item_detail to R.id.fragment_webview -> R.id.action_to_webview
 
-            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_to_webview
+            R.id.fragment_setting to R.id.fragment_webview -> R.id.action_to_webview
 
-            Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
+            R.id.fragment_account_setting to R.id.fragment_welcome -> R.id.action_to_welcome
 
-            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail
+            R.id.fragment_filter to R.id.fragment_item_detail -> R.id.action_filter_to_itemDetail
 
             else -> null
         }

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -69,6 +69,7 @@ class RoutePresenter(
     }
 
     private fun route(action: RouteAction) {
+        activity.setTheme(R.style.AppTheme)
         when (action) {
             is RouteAction.Welcome -> navigateToFragment(R.id.fragment_welcome)
             is RouteAction.Login -> navigateToFragment(R.id.fragment_fxa_login)

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -9,6 +9,7 @@ package mozilla.lockbox.presenter
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
@@ -42,20 +43,25 @@ class RoutePresenter(
     private val settingStore: SettingStore = SettingStore.shared
 ) : Presenter() {
     private lateinit var navController: NavController
+    private lateinit var backListener: OnBackPressedCallback
 
     override fun onViewReady() {
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
+        backListener = OnBackPressedCallback {
+            dispatcher.dispatch(RouteAction.InternalBack)
+            false
+        }
     }
 
     override fun onPause() {
         super.onPause()
-
+        activity.removeOnBackPressedCallback(backListener)
         compositeDisposable.clear()
     }
 
     override fun onResume() {
         super.onResume()
-
+        activity.addOnBackPressedCallback(backListener)
         routeStore.routes
             .observeOn(mainThread())
             .subscribe(this::route)
@@ -179,6 +185,7 @@ class RoutePresenter(
                 while (navController.popBackStack()) {
                     // NOP
                 }
+                routeStore.clearBackStack()
             }
         }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -195,9 +195,11 @@ class RoutePresenter(
         // If a RouteAction is called from a place the graph doesn't know about then
         // the app will log.error.
         return when (Pair(from, to)) {
-            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_webview
-            Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
+            Pair(R.id.fragment_null, R.id.fragment_item_list) -> R.id.action_init_to_unlocked
+            Pair(R.id.fragment_null, R.id.fragment_locked) -> R.id.action_init_to_locked
+            Pair(R.id.fragment_null, R.id.fragment_welcome) -> R.id.action_init_to_unprepared
+
+            Pair(R.id.fragment_welcome, R.id.fragment_fxa_login) -> R.id.action_welcome_to_fxaLogin
 
             Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
             Pair(R.id.fragment_fxa_login, R.id.fragment_fingerprint_onboarding) ->
@@ -211,6 +213,7 @@ class RoutePresenter(
                 R.id.action_onboarding_fingerprint_to_autofill
 
             Pair(R.id.fragment_autofill_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_autofill_onboarding, R.id.fragment_onboarding_confirmation) -> R.id.action_autofill_onboarding_to_confirmation
 
             Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
             Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_to_webview

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -120,7 +120,7 @@ class RoutePresenter(
                     }
                 }
             }
-            .flatMapIterable { it }
+            .flatMapIterable { listOf(RouteAction.InternalBack) + it }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
     }
@@ -140,12 +140,10 @@ class RoutePresenter(
                     negativeButtonTitle = R.string.cancel
                 )
             }
-            .map {
-                autoLockValues[it]
+            .flatMapIterable {
+                listOf(RouteAction.InternalBack, SettingAction.AutoLockTime(autoLockValues[it]))
             }
-            .subscribe {
-                dispatcher.dispatch(SettingAction.AutoLockTime(it))
-            }
+            .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
     }
 

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -47,7 +47,10 @@ class RoutePresenter(
     private val settingStore: SettingStore = SettingStore.shared
 ) : Presenter() {
     private lateinit var navController: NavController
-    private lateinit var backListener: OnBackPressedCallback
+    private val backListener = OnBackPressedCallback {
+        dispatcher.dispatch(RouteAction.InternalBack)
+        false
+    }
 
     private val navHostFragmentManager: FragmentManager
         get() {
@@ -63,10 +66,6 @@ class RoutePresenter(
 
     override fun onViewReady() {
         navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
-        backListener = OnBackPressedCallback {
-            dispatcher.dispatch(RouteAction.InternalBack)
-            false
-        }
     }
 
     override fun onPause() {

--- a/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/RouteStore.kt
@@ -55,8 +55,7 @@ open class RouteStore(
                         is DialogAction,
                         is RouteAction.AutoLockSetting,
                         is RouteAction.DialogFragment,
-                        is RouteAction.OpenWebsite,
-                        is RouteAction.SystemSetting -> true
+                        is RouteAction.SystemIntent -> true
                         else -> false
                     }
                 }

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -64,4 +64,10 @@ object Constant {
         const val errorTimeoutMillis: Long = 1600
         const val successDelayMillis: Long = 1300
     }
+
+    object RequestCode {
+        const val noResult = 0
+
+        const val unlock = 221
+    }
 }

--- a/app/src/main/java/mozilla/lockbox/view/BackableFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/BackableFragment.kt
@@ -2,8 +2,12 @@ package mozilla.lockbox.view
 
 import android.os.Bundle
 import android.view.View
+import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.ui.setupWithNavController
+import com.jakewharton.rxbinding2.support.v7.widget.navigationClicks
+import io.reactivex.Observable
+import kotlinx.android.synthetic.main.fragment_item_list.view.*
 import kotlinx.android.synthetic.main.include_backable.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.BackablePresenter
@@ -11,15 +15,22 @@ import mozilla.lockbox.presenter.BackableView
 
 open class BackableFragment : Fragment(), BackableView {
     private lateinit var backablePresenter: BackablePresenter
+    private lateinit var navController: NavController
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val navController = requireActivity().findNavController(R.id.fragment_nav_host)
+        navController = requireActivity().findNavController(R.id.fragment_nav_host)
         view.toolbar.setupWithNavController(navController)
         view.toolbar.setNavigationIcon(R.drawable.ic_arrow_back)
         view.toolbar.setNavigationContentDescription(R.string.backable_description)
+
         backablePresenter = BackablePresenter(this)
         backablePresenter.onViewReady()
 
         super.onViewCreated(view, savedInstanceState)
     }
+
+    override val backButtonClicks: Observable<Unit>
+        get() = view!!.toolbar.navigationClicks().doOnEach {
+            navController.popBackStack()
+        }
 }

--- a/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
@@ -21,6 +21,7 @@ import kotlinx.android.synthetic.main.fragment_locked.view.*
 import mozilla.lockbox.R
 import mozilla.lockbox.presenter.LockedPresenter
 import mozilla.lockbox.presenter.LockedView
+import mozilla.lockbox.support.Constant
 import java.lang.Exception
 
 class LockedFragment : Fragment(), LockedView {
@@ -39,23 +40,14 @@ class LockedFragment : Fragment(), LockedView {
         get() = view!!.unlockButton.clicks()
 
     override fun unlockFallback() {
-        val manager = context?.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-        val intent = manager.createConfirmDeviceCredentialIntent(
-            getString(R.string.unlock_fallback_title),
-            getString(R.string.confirm_pattern)
-        )
-        try {
-            startActivityForResult(intent, LOCK_REQUEST_CODE)
-        } catch (exception: Exception) {
-            _unlockConfirmed.onNext(false)
-        }
+        // Deleted
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == RESULT_OK) {
             when (requestCode) {
-                LOCK_REQUEST_CODE -> _unlockConfirmed.onNext(true)
+                Constant.RequestCode.unlock -> _unlockConfirmed.onNext(true)
             }
         } else {
             _unlockConfirmed.onNext(false)

--- a/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
@@ -24,10 +24,6 @@ import mozilla.lockbox.support.Constant
 class LockedFragment : Fragment(), LockedView {
     private val _unlockConfirmed = PublishSubject.create<Boolean>()
 
-    companion object {
-        private const val LOCK_REQUEST_CODE = 221
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         presenter = LockedPresenter(this)
         return inflater.inflate(R.layout.fragment_locked, container, false)
@@ -35,10 +31,6 @@ class LockedFragment : Fragment(), LockedView {
 
     override val unlockButtonTaps: Observable<Unit>
         get() = view!!.unlockButton.clicks()
-
-    override fun unlockFallback() {
-        // Deleted
-    }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)

--- a/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/LockedFragment.kt
@@ -7,8 +7,6 @@
 package mozilla.lockbox.view
 
 import android.app.Activity.RESULT_OK
-import android.app.KeyguardManager
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -22,7 +20,6 @@ import mozilla.lockbox.R
 import mozilla.lockbox.presenter.LockedPresenter
 import mozilla.lockbox.presenter.LockedView
 import mozilla.lockbox.support.Constant
-import java.lang.Exception
 
 class LockedFragment : Fragment(), LockedView {
     private val _unlockConfirmed = PublishSubject.create<Boolean>()

--- a/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
@@ -19,7 +19,6 @@ class RootActivity : AppCompatActivity() {
     private var presenter: RoutePresenter = RoutePresenter(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        setTheme(R.style.AppTheme)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_root)
         if (!isDebug()) window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)

--- a/app/src/main/res/layout/fragment_onboarding_confirmation.xml
+++ b/app/src/main/res/layout/fragment_onboarding_confirmation.xml
@@ -9,7 +9,6 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@null"
         android:id="@+id/fragment_onboarding_confirmation">
 
     <TextView

--- a/app/src/main/res/navigation/graph_main.xml
+++ b/app/src/main/res/navigation/graph_main.xml
@@ -9,7 +9,27 @@
             xmlns:app="http://schemas.android.com/apk/res-auto"
             xmlns:tools="http://schemas.android.com/tools"
             android:id="@+id/graph_main"
-            app:startDestination="@id/fragment_item_list">
+            app:startDestination="@id/fragment_null">
+    <fragment
+            android:id="@+id/fragment_null"
+            android:name="androidx.fragment.app.Fragment"
+            tools:layout="@null">
+        <action android:id="@+id/action_init_to_locked"
+                app:destination="@id/fragment_locked"
+                app:launchSingleTop="true"
+                app:popUpTo="@id/fragment_locked"
+                app:popUpToInclusive="true" />
+        <action android:id="@+id/action_init_to_unlocked"
+                app:destination="@id/fragment_item_list"
+                app:launchSingleTop="true"
+                app:popUpTo="@id/fragment_item_list"
+                app:popUpToInclusive="true" />
+        <action android:id="@+id/action_init_to_unprepared"
+                app:destination="@id/fragment_welcome"
+                app:launchSingleTop="true"
+                app:popUpTo="@id/fragment_welcome"
+                app:popUpToInclusive="true" />
+    </fragment>
 
     <fragment
             android:id="@+id/fragment_welcome"
@@ -55,6 +75,8 @@
             android:id="@+id/fragment_autofill_onboarding"
             android:name="mozilla.lockbox.view.AutofillOnboardingFragment"
             tools:layout="@layout/fragment_autofill_onboarding">
+        <action android:id="@+id/action_autofill_onboarding_to_confirmation"
+                app:destination="@id/fragment_onboarding_confirmation"/>
     </fragment>
 
     <fragment
@@ -65,6 +87,7 @@
                 android:id="@+id/action_onboarding_confirmation_to_itemList"
                 app:launchSingleTop="true"
                 app:destination="@id/fragment_item_list"
+                app:popUpTo="@id/fragment_item_list"
                 app:popUpToInclusive="true"/>
     </fragment>
 
@@ -158,6 +181,7 @@
                 android:id="@+id/action_locked_to_itemList"
                 app:destination="@id/fragment_item_list"
                 app:launchSingleTop="true"
+                app:popUpTo="@id/fragment_item_list"
                 app:popUpToInclusive="true"/>
         <action
                 android:id="@+id/action_locked_to_welcome"

--- a/app/src/test/java/mozilla/lockbox/StackReplaySubjectTest.kt
+++ b/app/src/test/java/mozilla/lockbox/StackReplaySubjectTest.kt
@@ -1,0 +1,144 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox
+
+import io.reactivex.observers.TestObserver
+import junit.framework.Assert.assertEquals
+import mozilla.lockbox.extensions.assertLastValue
+
+import mozilla.lockbox.flux.StackReplaySubject
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class StackReplaySubjectTest {
+
+    private val subject = StackReplaySubject.create<Int>()
+
+    private val testObserver = TestObserver<Int>()
+
+    @Test
+    fun testSimpleObserving() {
+        subject.subscribe(testObserver)
+
+        subject.onNext(0)
+        testObserver.assertLastValue(0)
+
+        subject.onNext(1)
+        testObserver.assertLastValue(1)
+    }
+
+    @Test
+    fun testingSubscriptionDisposal() {
+        val flag = AtomicInteger(0)
+        val disposable1 = subject.subscribe {
+            flag.incrementAndGet()
+        }
+
+        flag.set(0)
+        subject.onNext(0)
+        assertEquals(1, flag.get())
+
+        val disposable2 = subject.subscribe {
+            flag.incrementAndGet()
+        }
+
+        flag.set(0)
+        subject.onNext(0)
+        assertEquals(2, flag.get())
+
+        flag.set(0)
+        disposable1.dispose()
+        subject.onNext(0)
+        assertEquals(1, flag.get())
+
+        flag.set(0)
+        disposable2.dispose()
+
+        subject.onNext(0)
+        assertEquals(0, flag.get())
+    }
+
+    @Test
+    fun testReplay() {
+        subject.onNext(1)
+        subject.onNext(2)
+        assertEquals(2, subject.getSize())
+
+        subject.subscribe(testObserver)
+        testObserver.assertLastValue(2)
+
+        subject.onNext(3)
+        assertEquals(3, subject.getSize())
+        testObserver.assertLastValue(3)
+    }
+
+    @Test
+    fun testReplayOnEmpty() {
+        assertEquals(0, subject.getSize())
+        subject.subscribe(testObserver)
+        testObserver.assertEmpty()
+    }
+
+    @Test
+    fun testPop() {
+        subject.onNext(1)
+        subject.onNext(2)
+        assertEquals(2, subject.getSize())
+
+        subject.pop()
+        assertEquals(1, subject.getSize())
+        subject.subscribe(testObserver)
+        testObserver.assertLastValue(1)
+
+        // pop isn't observed.
+        subject.onNext(3)
+        assertEquals(2, subject.getSize())
+        testObserver.assertLastValue(3)
+        subject.pop()
+        assertEquals(1, subject.getSize())
+        testObserver.assertLastValue(3)
+    }
+
+    @Test
+    fun testTrim() {
+        subject.onNext(1)
+        subject.onNext(2)
+        subject.onNext(3)
+        assertEquals(3, subject.getSize())
+
+        subject.trim(2, 3)
+        assertEquals(1, subject.getSize())
+        subject.subscribe(testObserver)
+        testObserver.assertLastValue(1)
+    }
+
+    @Test
+    fun testClear() {
+        subject.onNext(1)
+        subject.onNext(2)
+        subject.onNext(3)
+        assertEquals(3, subject.getSize())
+        subject.clear()
+        assertEquals(0, subject.getSize())
+
+        subject.subscribe(testObserver)
+        testObserver.assertEmpty()
+    }
+
+    @Test
+    fun testTrimTail() {
+        subject.onNext(1)
+        subject.onNext(2)
+        subject.onNext(3)
+        assertEquals(3, subject.getSize())
+
+        subject.trimTail()
+        assertEquals(1, subject.getSize())
+        subject.subscribe(testObserver)
+        testObserver.assertLastValue(3)
+    }
+}

--- a/app/src/test/java/mozilla/lockbox/store/RouteStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/RouteStoreTest.kt
@@ -59,10 +59,14 @@ class RouteStoreTest {
         routeObserver.assertLastValue(RouteAction.ItemList)
 
         dispatcher.dispatch(RouteAction.SystemSetting(SettingIntent.Security))
-        routeObserver.assertLastValue(RouteAction.NoFollowOnReturn)
+        val routeObserver1 = TestObserver.create<RouteAction>()
+        subject.routes.subscribe(routeObserver1)
+        routeObserver1.assertLastValue(RouteAction.ItemList)
 
         dispatcher.dispatch(RouteAction.OpenWebsite("https://mozilla.org"))
-        routeObserver.assertLastValue(RouteAction.NoFollowOnReturn)
+        val routeObserver2 = TestObserver.create<RouteAction>()
+        subject.routes.subscribe(routeObserver2)
+        routeObserver2.assertLastValue(RouteAction.ItemList)
     }
 
     @Test


### PR DESCRIPTION
As navigation and rx are very well designed, they encapsulate their inner state very well. Unfortunately, this causes problems for our app: 

 * the app takes sometime to start up, and it's clear what the first thing the user should see in the meantime.
 * modelling the navigation back stack simplistically complicates this because we don't know how we should start.

Fixes #452
Fixes #448
Fixes #415

This PR does several things: 

 * adds a blank fragment whose only job is to be blank while a splash screen is displayed via a theme. This should be dismissed pretty quickly, but avoid a flash of an item list screen.
 * introduces a stack replay subject, with tests
 * uses the new subject to model the back stack of the application in a way not possible before. 
 * double checks that the `graph_main.xml` has all the correct XML files.
 * fixes `IllegalStateException`s being through by navigation controller.

This is not ready to land yet because: 

 * opening an item detail view and then opening the host in a browser, then clicking back twice should take you to the item list, instead, the second back is ignored. This is caused by:
 * as part of PR #485, we moved to subscribe and unsubscribe from the `RouteStore` eagerly, in `onPause` and `onResume`. This, I think, was a mistake. Instead, we should either make the autofill extension use its own RouteStore, use separate Autofil versions of FingerprintDialogAction, ensure only one subscriber is allowed at a time for the route store; or something else.
 * the `StackReplaySubject` is largely a cut and paste and change version of the `PublishSubject`. This could do with a tidy.

Asking for early feedback for this PR.