### PR TITLE
[WIP] 508: Merge `RoutePresenter` and `AutofillRoutePresenter`

### DIFF
--- a/app/src/androidTest/java/mozilla/lockbox/AppRoutePresenterTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/AppRoutePresenterTest.kt
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith
  */
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
-open class RoutePresenterTest {
+open class AppRoutePresenterTest {
     private val navigator = Navigator()
 
     @Rule @JvmField

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -1,0 +1,234 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.presenter
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.annotation.IdRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxkotlin.addTo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.R
+import mozilla.lockbox.action.AppWebPageAction
+import mozilla.lockbox.action.DialogAction
+import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.action.Setting
+import mozilla.lockbox.action.SettingAction
+import mozilla.lockbox.extensions.view.AlertDialogHelper
+import mozilla.lockbox.extensions.view.AlertState
+import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.log
+import mozilla.lockbox.store.RouteStore
+import mozilla.lockbox.store.SettingStore
+import mozilla.lockbox.view.AppWebPageFragmentArgs
+import mozilla.lockbox.view.DialogFragment
+import mozilla.lockbox.view.FingerprintAuthDialogFragment
+import mozilla.lockbox.view.ItemDetailFragmentArgs
+
+@ExperimentalCoroutinesApi
+class AppRoutePresenter(
+    private val activity: AppCompatActivity,
+    private val dispatcher: Dispatcher = Dispatcher.shared,
+    private val routeStore: RouteStore = RouteStore.shared,
+    private val settingStore: SettingStore = SettingStore.shared
+) : RoutePresenter(activity) {
+
+    private lateinit var navController: NavController
+
+    override fun onViewReady() {
+        navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        compositeDisposable.clear()
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        routeStore.routes
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(this::route)
+            .addTo(compositeDisposable)
+    }
+
+    private fun route(action: RouteAction) {
+        when (action) {
+            is RouteAction.Welcome -> navigateTo(R.id.fragment_welcome)
+            is RouteAction.Login -> navigateTo(R.id.fragment_fxa_login)
+            is RouteAction.Onboarding.FingerprintAuth ->
+                navigateTo(R.id.fragment_fingerprint_onboarding)
+            is RouteAction.Onboarding.Autofill -> navigateTo(R.id.fragment_autofill_onboarding)
+            is RouteAction.Onboarding.Confirmation -> navigateTo(R.id.fragment_onboarding_confirmation)
+            is RouteAction.ItemList -> navigateTo(R.id.fragment_item_list)
+            is RouteAction.SettingList -> navigateTo(R.id.fragment_setting)
+            is RouteAction.AccountSetting -> navigateTo(R.id.fragment_account_setting)
+            is RouteAction.LockScreen -> navigateTo(R.id.fragment_locked)
+            is RouteAction.Filter -> navigateTo(R.id.fragment_filter)
+            is RouteAction.ItemDetail -> navigateTo(R.id.fragment_item_detail, bundle(action))
+            is RouteAction.OpenWebsite -> openWebsite(action.url)
+            is RouteAction.SystemSetting -> openSetting(action)
+            is RouteAction.AutoLockSetting -> showAutoLockSelections()
+            is RouteAction.DialogFragment.FingerprintDialog ->
+                showDialogFragment(FingerprintAuthDialogFragment(), action)
+            is DialogAction -> showDialog(action)
+            is AppWebPageAction -> navigateTo(R.id.fragment_webview, bundle(action))
+        }
+    }
+
+    private fun navigateTo(@IdRes destinationId: Int, args: Bundle? = null) {
+        val srcId = getSourceId(navController, destinationId) ?: return
+
+        if (srcId == destinationId && args == null) {
+            // No point in navigating if nothing has changed.
+            return
+        }
+
+        val transition = findTransitionId(srcId, destinationId) ?: destinationId
+
+        super.navigateToFragment(navController, destinationId, transition, args)
+    }
+
+
+
+    private fun bundle(action: AppWebPageAction): Bundle {
+        return AppWebPageFragmentArgs.Builder()
+            .setUrl(action.url!!)
+            .setTitle(action.title!!)
+            .build()
+            .toBundle()
+    }
+
+    private fun bundle(action: RouteAction.ItemDetail): Bundle {
+        return ItemDetailFragmentArgs.Builder()
+            .setItemId(action.id)
+            .build()
+            .toBundle()
+    }
+
+    private fun showDialog(destination: DialogAction) {
+        AlertDialogHelper.showAlertDialog(activity, destination.viewModel)
+            .map { alertState ->
+                when (alertState) {
+                    AlertState.BUTTON_POSITIVE -> {
+                        destination.positiveButtonActionList
+                    }
+                    AlertState.BUTTON_NEGATIVE -> {
+                        destination.negativeButtonActionList
+                    }
+                }
+            }
+            .flatMapIterable { it }
+            .subscribe(dispatcher::dispatch)
+            .addTo(compositeDisposable)
+    }
+
+    private fun showAutoLockSelections() {
+        val autoLockValues = Setting.AutoLockTime.values()
+        val items = autoLockValues.map { it.stringValue }.toTypedArray()
+
+        settingStore.autoLockTime.take(1)
+            .map { autoLockValues.indexOf(it) }
+            .flatMap {
+                AlertDialogHelper.showRadioAlertDialog(
+                    activity,
+                    R.string.auto_lock,
+                    items,
+                    it,
+                    negativeButtonTitle = R.string.cancel
+                )
+            }
+            .map {
+                autoLockValues[it]
+            }
+            .subscribe {
+                dispatcher.dispatch(SettingAction.AutoLockTime(it))
+            }
+            .addTo(compositeDisposable)
+    }
+
+    // could possibly put this in RoutePresenter? slight differences between these versions
+    private fun showDialogFragment(dialogFragment: DialogFragment?, destination: RouteAction.DialogFragment) {
+        if (dialogFragment != null) {
+            val fragmentManager = activity.supportFragmentManager
+            try {
+                dialogFragment.setTargetFragment(fragmentManager.fragments.last(), 0)
+                dialogFragment.show(fragmentManager, dialogFragment.javaClass.name)
+                dialogFragment.setupDialog(destination.dialogTitle, destination.dialogSubtitle)
+            } catch (e: IllegalStateException) {
+                log.error("Could not show dialog", e)
+            }
+        }
+    }
+
+    private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
+        // This maps two nodes in the graph_main.xml to the edge between them.
+        // If a RouteAction is called from a place the graph doesn't know about then
+        // the app will log.error.
+        return when (Pair(from, to)) {
+            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_webview
+            Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
+
+            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
+            Pair(R.id.fragment_fxa_login, R.id.fragment_fingerprint_onboarding) ->
+                R.id.action_fxaLogin_to_fingerprint_onboarding
+            Pair(R.id.fragment_fxa_login, R.id.fragment_onboarding_confirmation) ->
+                R.id.action_fxaLogin_to_onboarding_confirmation
+
+            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_onboarding_confirmation) ->
+                R.id.action_fingerprint_onboarding_to_confirmation
+            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_autofill_onboarding) ->
+                R.id.action_onboarding_fingerprint_to_autofill
+
+            Pair(R.id.fragment_autofill_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
+
+            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_locked, R.id.fragment_welcome) -> R.id.action_locked_to_welcome
+
+            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> R.id.action_itemList_to_itemDetail
+            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> R.id.action_itemList_to_setting
+            Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> R.id.action_itemList_to_accountSetting
+            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_to_locked
+            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
+            Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
+
+            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail
+
+            else -> null
+        }
+    }
+
+    private fun openWebsite(url: String) {
+        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        activity.startActivity(browserIntent, null)
+    }
+
+    private fun openSetting(settingAction: RouteAction.SystemSetting) {
+        val settingIntent = Intent(settingAction.setting.intentAction)
+        settingIntent.data = settingAction.setting.data
+        activity.startActivity(settingIntent, null)
+    }
+
+
+
+}

--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -87,19 +87,8 @@ class AppRoutePresenter(
     }
 
     private fun navigateTo(@IdRes destinationId: Int, args: Bundle? = null) {
-        val srcId = getSourceId(navController, destinationId) ?: return
-
-        if (srcId == destinationId && args == null) {
-            // No point in navigating if nothing has changed.
-            return
-        }
-
-        val transition = findTransitionId(srcId, destinationId) ?: destinationId
-
-        super.navigateToFragment(navController, destinationId, transition, args)
+        super.navigateToFragment(navController, destinationId, args)
     }
-
-
 
     private fun bundle(action: AppWebPageAction): Bundle {
         return AppWebPageFragmentArgs.Builder()
@@ -171,53 +160,6 @@ class AppRoutePresenter(
         }
     }
 
-    private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
-        // This maps two nodes in the graph_main.xml to the edge between them.
-        // If a RouteAction is called from a place the graph doesn't know about then
-        // the app will log.error.
-        return when (Pair(from, to)) {
-            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_webview
-            Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
-
-            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
-            Pair(R.id.fragment_fxa_login, R.id.fragment_fingerprint_onboarding) ->
-                R.id.action_fxaLogin_to_fingerprint_onboarding
-            Pair(R.id.fragment_fxa_login, R.id.fragment_onboarding_confirmation) ->
-                R.id.action_fxaLogin_to_onboarding_confirmation
-
-            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_onboarding_confirmation) ->
-                R.id.action_fingerprint_onboarding_to_confirmation
-            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_autofill_onboarding) ->
-                R.id.action_onboarding_fingerprint_to_autofill
-
-            Pair(R.id.fragment_autofill_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
-
-            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_locked, R.id.fragment_welcome) -> R.id.action_locked_to_welcome
-
-            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> R.id.action_itemList_to_itemDetail
-            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> R.id.action_itemList_to_setting
-            Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> R.id.action_itemList_to_accountSetting
-            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_to_locked
-            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
-            Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
-
-            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail
-
-            else -> null
-        }
-    }
-
     private fun openWebsite(url: String) {
         val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
         activity.startActivity(browserIntent, null)
@@ -228,7 +170,4 @@ class AppRoutePresenter(
         settingIntent.data = settingAction.setting.data
         activity.startActivity(settingIntent, null)
     }
-
-
-
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
@@ -92,26 +92,7 @@ class AutofillRoutePresenter(
     }
 
     private fun navigateTo(@IdRes destinationId: Int, args: Bundle? = null) {
-        val srcId = getSourceId(navController, destinationId) ?: return
-
-        if (srcId == destinationId && args == null) {
-            // No point in navigating if nothing has changed.
-            return
-        }
-
-        val transition = findTransitionId(srcId, destinationId) ?: destinationId
-
-        super.navigateToFragment(navController, destinationId, transition, args)
-    }
-
-
-    private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
-        return when (Pair(from, to)) {
-            Pair(R.id.fragment_locked, R.id.fragment_filter) -> R.id.action_locked_to_filter
-            Pair(R.id.fragment_null, R.id.fragment_filter) -> R.id.action_to_filter
-            Pair(R.id.fragment_null, R.id.fragment_locked) -> R.id.action_to_locked
-            else -> null
-        }
+        super.navigateToFragment(navController, destinationId, args)
     }
 
     // could possibly put this in RoutePresenter? slight differences between these versions

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -6,163 +6,22 @@
 
 package mozilla.lockbox.presenter
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
-import androidx.navigation.Navigation
-import io.reactivex.android.schedulers.AndroidSchedulers.mainThread
-import io.reactivex.rxkotlin.addTo
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import mozilla.lockbox.R
-import mozilla.lockbox.action.AppWebPageAction
-import mozilla.lockbox.action.DialogAction
-import mozilla.lockbox.action.RouteAction
-import mozilla.lockbox.action.Setting
-import mozilla.lockbox.action.SettingAction
-import mozilla.lockbox.extensions.view.AlertDialogHelper
-import mozilla.lockbox.extensions.view.AlertState
-import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Presenter
 import mozilla.lockbox.log
-import mozilla.lockbox.store.RouteStore
-import mozilla.lockbox.store.SettingStore
-import mozilla.lockbox.view.AppWebPageFragmentArgs
-import mozilla.lockbox.view.DialogFragment
-import mozilla.lockbox.view.FingerprintAuthDialogFragment
-import mozilla.lockbox.view.ItemDetailFragmentArgs
 
 @ExperimentalCoroutinesApi
-class RoutePresenter(
-    private val activity: AppCompatActivity,
-    private val dispatcher: Dispatcher = Dispatcher.shared,
-    private val routeStore: RouteStore = RouteStore.shared,
-    private val settingStore: SettingStore = SettingStore.shared
+open class RoutePresenter(
+    private val activity: AppCompatActivity
 ) : Presenter() {
-    private lateinit var navController: NavController
 
-    override fun onViewReady() {
-        navController = Navigation.findNavController(activity, R.id.fragment_nav_host)
-    }
-
-    override fun onPause() {
-        super.onPause()
-
-        compositeDisposable.clear()
-    }
-
-    override fun onResume() {
-        super.onResume()
-
-        routeStore.routes
-            .observeOn(mainThread())
-            .subscribe(this::route)
-            .addTo(compositeDisposable)
-    }
-
-    private fun route(action: RouteAction) {
-        when (action) {
-            is RouteAction.Welcome -> navigateToFragment(R.id.fragment_welcome)
-            is RouteAction.Login -> navigateToFragment(R.id.fragment_fxa_login)
-            is RouteAction.Onboarding.FingerprintAuth ->
-                navigateToFragment(R.id.fragment_fingerprint_onboarding)
-            is RouteAction.Onboarding.Autofill -> navigateToFragment(R.id.fragment_autofill_onboarding)
-            is RouteAction.Onboarding.Confirmation -> navigateToFragment(R.id.fragment_onboarding_confirmation)
-            is RouteAction.ItemList -> navigateToFragment(R.id.fragment_item_list)
-            is RouteAction.SettingList -> navigateToFragment(R.id.fragment_setting)
-            is RouteAction.AccountSetting -> navigateToFragment(R.id.fragment_account_setting)
-            is RouteAction.LockScreen -> navigateToFragment(R.id.fragment_locked)
-            is RouteAction.Filter -> navigateToFragment(R.id.fragment_filter)
-            is RouteAction.ItemDetail -> navigateToFragment(R.id.fragment_item_detail, bundle(action))
-            is RouteAction.OpenWebsite -> openWebsite(action.url)
-            is RouteAction.SystemSetting -> openSetting(action)
-            is RouteAction.AutoLockSetting -> showAutoLockSelections()
-            is RouteAction.DialogFragment.FingerprintDialog ->
-                showDialogFragment(FingerprintAuthDialogFragment(), action)
-            is DialogAction -> showDialog(action)
-            is AppWebPageAction -> navigateToFragment(R.id.fragment_webview, bundle(action))
-        }
-    }
-
-    private fun bundle(action: AppWebPageAction): Bundle {
-        return AppWebPageFragmentArgs.Builder()
-            .setUrl(action.url!!)
-            .setTitle(action.title!!)
-            .build()
-            .toBundle()
-    }
-
-    private fun bundle(action: RouteAction.ItemDetail): Bundle {
-        return ItemDetailFragmentArgs.Builder()
-            .setItemId(action.id)
-            .build()
-            .toBundle()
-    }
-
-    private fun showDialog(destination: DialogAction) {
-        AlertDialogHelper.showAlertDialog(activity, destination.viewModel)
-            .map { alertState ->
-                when (alertState) {
-                    AlertState.BUTTON_POSITIVE -> {
-                        destination.positiveButtonActionList
-                    }
-                    AlertState.BUTTON_NEGATIVE -> {
-                        destination.negativeButtonActionList
-                    }
-                }
-            }
-            .flatMapIterable { it }
-            .subscribe(dispatcher::dispatch)
-            .addTo(compositeDisposable)
-    }
-
-    private fun showAutoLockSelections() {
-        val autoLockValues = Setting.AutoLockTime.values()
-        val items = autoLockValues.map { it.stringValue }.toTypedArray()
-
-        settingStore.autoLockTime.take(1)
-            .map { autoLockValues.indexOf(it) }
-            .flatMap {
-                AlertDialogHelper.showRadioAlertDialog(
-                    activity,
-                    R.string.auto_lock,
-                    items,
-                    it,
-                    negativeButtonTitle = R.string.cancel
-                )
-            }
-            .map {
-                autoLockValues[it]
-            }
-            .subscribe {
-                dispatcher.dispatch(SettingAction.AutoLockTime(it))
-            }
-            .addTo(compositeDisposable)
-    }
-
-    private fun showDialogFragment(dialogFragment: DialogFragment?, destination: RouteAction.DialogFragment) {
-        if (dialogFragment != null) {
-            val fragmentManager = activity.supportFragmentManager
-            try {
-                dialogFragment.setTargetFragment(fragmentManager.fragments.last(), 0)
-                dialogFragment.show(fragmentManager, dialogFragment.javaClass.name)
-                dialogFragment.setupDialog(destination.dialogTitle, destination.dialogSubtitle)
-            } catch (e: IllegalStateException) {
-                log.error("Could not show dialog", e)
-            }
-        }
-    }
-    private fun navigateToFragment(@IdRes destinationId: Int, args: Bundle? = null) {
+    fun navigateToFragment(navController: NavController, @IdRes destinationId: Int, transition: Int,  args: Bundle? = null) {
         val src = navController.currentDestination ?: return
         val srcId = src.id
-        if (srcId == destinationId && args == null) {
-            // No point in navigating if nothing has changed.
-            return
-        }
-
-        val transition = findTransitionId(srcId, destinationId) ?: destinationId
 
         if (transition == destinationId) {
             // Without being able to detect if we're in developer mode,
@@ -190,61 +49,13 @@ class RoutePresenter(
         }
     }
 
-    private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
-        // This maps two nodes in the graph_main.xml to the edge between them.
-        // If a RouteAction is called from a place the graph doesn't know about then
-        // the app will log.error.
-        return when (Pair(from, to)) {
-            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_webview
-            Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
-
-            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
-            Pair(R.id.fragment_fxa_login, R.id.fragment_fingerprint_onboarding) ->
-                R.id.action_fxaLogin_to_fingerprint_onboarding
-            Pair(R.id.fragment_fxa_login, R.id.fragment_onboarding_confirmation) ->
-                R.id.action_fxaLogin_to_onboarding_confirmation
-
-            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_onboarding_confirmation) ->
-                R.id.action_fingerprint_onboarding_to_confirmation
-            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_autofill_onboarding) ->
-                R.id.action_onboarding_fingerprint_to_autofill
-
-            Pair(R.id.fragment_autofill_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
-
-            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_to_itemList
-            Pair(R.id.fragment_locked, R.id.fragment_welcome) -> R.id.action_locked_to_welcome
-
-            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> R.id.action_itemList_to_itemDetail
-            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> R.id.action_itemList_to_setting
-            Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> R.id.action_itemList_to_accountSetting
-            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_to_locked
-            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
-            Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_to_webview
-
-            Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
-
-            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail
-
-            else -> null
+    fun getSourceId(navController: NavController, @IdRes destinationId: Int) : Int? {
+        val src = navController.currentDestination ?: return null
+        val srcId = src.id
+        if (srcId == destinationId) {
+            // No point in navigating if nothing has changed.
+            return null
         }
-    }
-
-    private fun openWebsite(url: String) {
-        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        activity.startActivity(browserIntent, null)
-    }
-
-    private fun openSetting(settingAction: RouteAction.SystemSetting) {
-        val settingIntent = Intent(settingAction.setting.intentAction)
-        settingIntent.data = settingAction.setting.data
-        activity.startActivity(settingIntent, null)
+        return destinationId
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -11,6 +11,7 @@ import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.R
 import mozilla.lockbox.flux.Presenter
 import mozilla.lockbox.log
 
@@ -19,9 +20,15 @@ open class RoutePresenter(
     private val activity: AppCompatActivity
 ) : Presenter() {
 
-    fun navigateToFragment(navController: NavController, @IdRes destinationId: Int, transition: Int,  args: Bundle? = null) {
+    fun navigateToFragment(navController: NavController, @IdRes destinationId: Int, args: Bundle? = null) {
         val src = navController.currentDestination ?: return
         val srcId = src.id
+        if (srcId == destinationId && args == null) {
+            // No point in navigating if nothing has changed.
+            return
+        }
+
+        val transition = findTransitionId(srcId, destinationId) ?: destinationId
 
         if (transition == destinationId) {
             // Without being able to detect if we're in developer mode,
@@ -49,13 +56,55 @@ open class RoutePresenter(
         }
     }
 
-    fun getSourceId(navController: NavController, @IdRes destinationId: Int) : Int? {
-        val src = navController.currentDestination ?: return null
-        val srcId = src.id
-        if (srcId == destinationId) {
-            // No point in navigating if nothing has changed.
-            return null
+    private fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
+        // This maps two nodes in the graph_main.xml to the edge between them.
+        // If a RouteAction is called from a place the graph doesn't know about then
+        // the app will log.error.
+        return when (Pair(from, to)) {
+            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_welcome, R.id.fragment_item_list) -> R.id.action_to_webview
+            Pair(R.id.fragment_welcome, R.id.fragment_locked) -> R.id.action_to_locked
+
+            Pair(R.id.fragment_fxa_login, R.id.fragment_item_list) -> R.id.action_fxaLogin_to_itemList
+            Pair(R.id.fragment_fxa_login, R.id.fragment_fingerprint_onboarding) ->
+                R.id.action_fxaLogin_to_fingerprint_onboarding
+            Pair(R.id.fragment_fxa_login, R.id.fragment_onboarding_confirmation) ->
+                R.id.action_fxaLogin_to_onboarding_confirmation
+
+            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_onboarding_confirmation) ->
+                R.id.action_fingerprint_onboarding_to_confirmation
+            Pair(R.id.fragment_fingerprint_onboarding, R.id.fragment_autofill_onboarding) ->
+                R.id.action_onboarding_fingerprint_to_autofill
+
+            Pair(R.id.fragment_autofill_onboarding, R.id.fragment_item_list) -> R.id.action_to_itemList
+
+            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_onboarding_confirmation, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_locked, R.id.fragment_item_list) -> R.id.action_to_itemList
+            Pair(R.id.fragment_locked, R.id.fragment_welcome) -> R.id.action_locked_to_welcome
+
+            Pair(R.id.fragment_item_list, R.id.fragment_item_detail) -> R.id.action_itemList_to_itemDetail
+            Pair(R.id.fragment_item_list, R.id.fragment_setting) -> R.id.action_itemList_to_setting
+            Pair(R.id.fragment_item_list, R.id.fragment_account_setting) -> R.id.action_itemList_to_accountSetting
+            Pair(R.id.fragment_item_list, R.id.fragment_locked) -> R.id.action_to_locked
+            Pair(R.id.fragment_item_list, R.id.fragment_filter) -> R.id.action_itemList_to_filter
+            Pair(R.id.fragment_item_list, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_item_detail, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_setting, R.id.fragment_webview) -> R.id.action_to_webview
+
+            Pair(R.id.fragment_account_setting, R.id.fragment_welcome) -> R.id.action_to_welcome
+
+            Pair(R.id.fragment_filter, R.id.fragment_item_detail) -> R.id.action_filter_to_itemDetail
+
+            // autofill transitions
+            Pair(R.id.fragment_locked, R.id.fragment_filter) -> R.id.action_locked_to_filter
+            Pair(R.id.fragment_null, R.id.fragment_filter) -> R.id.action_to_filter
+            Pair(R.id.fragment_null, R.id.fragment_locked) -> R.id.action_to_locked
+
+            else -> null
         }
-        return destinationId
     }
 }

--- a/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/RootActivity.kt
@@ -11,12 +11,13 @@ import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
+import mozilla.lockbox.presenter.AppRoutePresenter
 import mozilla.lockbox.presenter.RoutePresenter
 import mozilla.lockbox.support.isDebug
 
 @ExperimentalCoroutinesApi
 class RootActivity : AppCompatActivity() {
-    private var presenter: RoutePresenter = RoutePresenter(this)
+    private var presenter: RoutePresenter = AppRoutePresenter(this)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(R.style.AppTheme)

--- a/app/src/test/java/mozilla/lockbox/presenter/AppRoutePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AppRoutePresenterTest.kt
@@ -1,0 +1,121 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.presenter
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
+import androidx.navigation.Navigation
+import io.reactivex.Observable
+import io.reactivex.observers.TestObserver
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.PublishSubject
+import kotlinx.android.synthetic.main.list_cell_no_entries.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.R
+import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.action.Setting
+import mozilla.lockbox.flux.Action
+import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.store.RouteStore
+import mozilla.lockbox.store.SettingStore
+import mozilla.lockbox.view.AutofillFilterFragment
+import mozilla.lockbox.view.FingerprintAuthDialogFragment
+import mozilla.lockbox.view.ItemListFragment
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.any
+import org.mockito.Mockito.verify
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(
+    Navigation::class,
+    Intent::class
+)
+class AppRoutePresenterTest {
+
+    @Mock
+    val navController: NavController = Mockito.mock(NavController::class.java)
+
+    @Mock
+    val navDestination: NavDestination = Mockito.mock(NavDestination::class.java)
+
+
+    @Mock
+    val itemListFragment: ItemListFragment = PowerMockito.mock(ItemListFragment::class.java)
+
+    @Mock
+    val fragmentManager: FragmentManager = Mockito.mock(FragmentManager::class.java)
+
+    @Mock
+    val activity: AppCompatActivity = Mockito.mock(AppCompatActivity::class.java)
+
+    class FakeRouteStore : RouteStore() {
+        val routeStub = PublishSubject.create<RouteAction>()
+        override val routes: Observable<RouteAction>
+            get() = routeStub
+    }
+
+    class FakeSettingStore : SettingStore() {
+        val itemListSortStub = BehaviorSubject.createDefault(Setting.ItemListSort.ALPHABETICALLY)
+        override var itemListSortOrder: Observable<Setting.ItemListSort> = itemListSortStub
+    }
+
+    private val dispatcher = Dispatcher()
+    private val dispatcherObserver = TestObserver.create<Action>()
+    private val routeStore = FakeRouteStore()
+    private val settingStore = FakeSettingStore()
+
+    var desinationIdStub = R.id.welcome_fragment
+
+    lateinit var subject: AppRoutePresenter
+
+    @Before
+    fun setUp() {
+        dispatcher.register.subscribe(dispatcherObserver)
+        PowerMockito.`when`(activity.supportFragmentManager).thenReturn(fragmentManager)
+        PowerMockito.`when`(navDestination.id).thenReturn(desinationIdStub)
+        PowerMockito.`when`(navController.currentDestination).thenReturn(navDestination)
+        PowerMockito.mockStatic(Navigation::class.java)
+        PowerMockito.`when`(Navigation.findNavController(activity, R.id.fragment_nav_host)).thenReturn(navController)
+
+        PowerMockito.whenNew(ItemListFragment::class.java).withNoArguments()
+            .thenReturn(itemListFragment)
+
+        subject = AppRoutePresenter(
+            activity,
+            dispatcher,
+            routeStore,
+            settingStore
+        )
+    }
+
+    // TODO
+    @Test
+    fun `routes navigate correctly`() {
+        desinationIdStub = R.id.action_to_itemList
+        routeStore.routeStub.onNext(RouteAction.ItemList)
+        subject.onViewReady()
+
+        verify(navController).navigate(R.id.action_to_itemList)
+    }
+
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,3 +16,4 @@ ignore:
   - "app/src/main/java/mozilla/lockbox/extensions/view"
   - "app/src/debug/java/mozilla/lockbox/view/UITestActivity.kt"
   - "app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt"
+  - "app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt"


### PR DESCRIPTION
Fixes #508

## Testing and Review Notes

Now we have the `AppRoutePresenter` and the `AutofillRoutePresenter`. These are inheriting the `navigateToFragment()` code, which lives in the `RoutePresenter`.

Methods in "parent" `RoutePresenter`:
  - `navigateToFragment`
  - `findTransitionId` (Pairs for Autofill added to the big list of transitions since they are unique)
  - _maybe showDialogFragment_ (see comments)

## Screenshots or Videos

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)