### PR TITLE
356: Remove AccountStore network connection checks

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -2,15 +2,6 @@
 <issues format="5" by="lint 3.3.1" client="gradle" variant="all" version="3.3.1">
 
     <issue
-        id="ObsoleteLintCustomCheck"
-        message="Lint found an issue registry (`mozilla.components.tooling.lint.LintIssueRegistry`) which is older than the current API level; these checks may not work correctly.&#xA;&#xA;Recompile the checks against the latest version. Custom check API version is 2 (3.2), current lint API level is 3 (3.3+)"
-        includedVariants="debug"
-        excludedVariants="release">
-        <location
-            file="../../../.gradle/caches/transforms-1/files-1.1/lib-publicsuffixlist-0.40.0.aar/89d62c37aacf8b1a44f832ced00759ad/jars/lint.jar"/>
-    </issue>
-
-    <issue
         id="MissingConstraints"
         message="This view is not constrained horizontally: at runtime it will jump to the left unless you add a horizontal constraint"
         errorLine1="        &lt;ImageView"
@@ -200,18 +191,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/strings.xml"
-            line="261"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
-        message="The resource `R.string.autofill_error_toast` appears to be unused"
-        errorLine1="    &lt;string name=&quot;autofill_error_toast&quot;>Firefox Lockbox encountered an error: %s&lt;/string>"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/strings.xml"
-            line="265"
+            line="254"
             column="13"/>
     </issue>
 

--- a/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
+++ b/app/src/main/java/mozilla/lockbox/action/DialogAction.kt
@@ -34,13 +34,6 @@ sealed class DialogAction(
         ),
         listOf(LifecycleAction.UserReset)
     )
-    object NoNetworkDisclaimer : DialogAction(
-        DialogViewModel(
-            R.string.no_network,
-            R.string.connect_to_internet,
-            R.string.ok
-        )
-    )
     object OnboardingSecurityDialog : DialogAction(
             DialogViewModel(
                 R.string.secure_your_device,

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -27,7 +27,6 @@ import mozilla.components.service.fxa.FirefoxAccount
 import mozilla.components.service.fxa.Profile
 import mozilla.lockbox.action.AccountAction
 import mozilla.lockbox.action.DataStoreAction
-import mozilla.lockbox.action.DialogAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
@@ -43,7 +42,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.CoroutineContext
 import org.mozilla.fxaclient.internal.FxaException as FxaException
 
-
 @ExperimentalCoroutinesApi
 open class AccountStore(
     private val lifecycleStore: LifecycleStore = LifecycleStore.shared,
@@ -58,11 +56,11 @@ open class AccountStore(
 
     private val exceptionHandler: CoroutineExceptionHandler
         get() = CoroutineExceptionHandler { _, e ->
-                log.error(
-                    message = "Unexpected error occurred during Firefox Account authentication",
-                    throwable = e
-                )
-            }
+            log.error(
+                message = "Unexpected error occurred during Firefox Account authentication",
+                throwable = e
+            )
+        }
 
     private val coroutineContext: CoroutineContext
         get() = Dispatchers.Default + exceptionHandler
@@ -107,9 +105,9 @@ open class AccountStore(
 
         // Moves credentials from the AccountStore, into the DataStore.
         syncCredentials.map {
-                it.value?.let { credentials -> DataStoreAction.UpdateCredentials(credentials) }
+            it.value?.let { credentials -> DataStoreAction.UpdateCredentials(credentials) }
                 ?: DataStoreAction.Reset
-            }
+        }
             .subscribe(dispatcher::dispatch)
             .addTo(compositeDisposable)
     }
@@ -221,12 +219,14 @@ open class AccountStore(
     }
 
     private fun pushError(it: Throwable) {
-        when(it) {
-            is FxaException.Unauthorized -> log.error("FxA error populating account information. Message: " + it.message, it)
+        when (it) {
+            is FxaException.Unauthorized -> log.error(
+                "FxA error populating account information. Message: " + it.message,
+                it
+            )
             is FxaException.Unspecified -> log.error("Unspecified FxA error. Message: " + it.message, it)
             is FxaException.Network -> log.error("FxA network error. Message: " + it.message, it)
             is FxaException.Panic -> log.error("FxA error. Message: " + it.message, it)
-            else -> null
         }
     }
 }

--- a/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/AccountStore.kt
@@ -121,7 +121,11 @@ open class AccountStore(
             if (accountJSON == Constant.App.testMarker) {
                 populateTestAccountInformation(false)
             } else {
-                this.fxa = FirefoxAccount.fromJSONString(accountJSON)
+                try {
+                    this.fxa = FirefoxAccount.fromJSONString(accountJSON)
+                } catch (e: FxaException) {
+                    pushError(e)
+                }
                 generateLoginURL()
                 populateAccountInformation(false)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,8 +12,6 @@
 
     <!-- This is the text on a button to cancel the current operation or request such as unlocking the application with a fingerprint -->
     <string name="cancel">Cancel</string>
-    <!-- This is the text on a button to confirm or continue with the current operation -->
-    <string name="ok">OK</string>
     <!-- This is the title of a link for users to tap to open a web page to learn more about a related setting or feature -->
     <string name="learn_more">Learn more</string>
     <!-- This is the label a screenreader uses to inform the user they selected a link that will open a webpage to learn more about the feature or setting -->
@@ -185,11 +183,6 @@
     <string name="disconnect_disclaimer_message">This will delete your Firefox Account information and all saved entries from Firefox Lockbox.</string>
     <!-- This is the text on a final confirmation button to sign out and disconnect the account from the application -->
     <string name="disconnect">Disconnect</string>
-
-    <!-- This is used as the title for an alert message to inform the user the app does not detect network connectivity -->
-    <string name="no_network">No Network</string>
-    <!-- This is displayed in an alert message to provide information and instruction to connect to the internet to use the application, not expected to translate Firefox Lockbox -->
-    <string name="connect_to_internet">Please connect to the internet to use Firefox Lockbox</string>
     <!-- This is the hint value for an autofill box that appears when suggesting a value for a password field. It is interpolated with the user's account name. -->
     <string name="password_for">Password for %1$s</string>
 


### PR DESCRIPTION
Fixes #356 

## Testing and Review Notes
Added specific logs for the specified `FxaException`:

```
    class Unspecified(msg: String) : FxaException(msg)
    class Unauthorized(msg: String) : FxaException(msg)
    class Network(msg: String) : FxaException(msg)
    class Panic(msg: String) : FxaException(msg)
```

**Results**: Users will not know that the network is down if they are on the Welcome screen. Once they navigate to Login, they will see our network error bar displayed.

## Screenshots or Videos
Example network error from logs:
```
E/Lockbox: FxA network error. Message: Network error: https://accounts.firefox.com/.well-known/fxa-client-configuration: an error occurred trying to connect: failed to lookup address information: No address associated with hostname
    org.mozilla.fxaclient.internal.FxaException$Network: Network error: https://accounts.firefox.com/.well-known/fxa-client-configuration: an error occurred trying to connect: failed to lookup address information: No address associated with hostname
        at org.mozilla.fxaclient.internal.FxaException$Companion.fromConsuming$fxa_client_library_withoutLib(FxaException.kt:26)
        at org.mozilla.fxaclient.internal.FirefoxAccount.beginOAuthFlow(FirefoxAccount.kt:194)
        at mozilla.components.service.fxa.FirefoxAccount$beginOAuthFlow$1.invokeSuspend(FirefoxAccount.kt:60)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:32)
        at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:233)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:594)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.access$runSafely(CoroutineScheduler.kt:60)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:742)
```
## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
