### PR TITLE
514 text error is not correctly aligned

### DIFF
--- a/app/src/main/res/layout/fragment_fingerprint_dialog.xml
+++ b/app/src/main/res/layout/fragment_fingerprint_dialog.xml
@@ -58,6 +58,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
+            android:gravity="center"
             android:fontFamily="sans-serif"
             android:lineSpacingExtra="6.5sp"
             android:paddingStart="16dp"

--- a/app/src/main/res/layout/fragment_fingerprint_dialog.xml
+++ b/app/src/main/res/layout/fragment_fingerprint_dialog.xml
@@ -60,6 +60,8 @@
             android:layout_marginTop="12dp"
             android:fontFamily="sans-serif"
             android:lineSpacingExtra="6.5sp"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
             android:text="@string/touch_fingerprint_sensor"
             android:textColor="@color/gray_73_percent"
             android:textSize="13sp"


### PR DESCRIPTION
Fixes #514 

## Testing and Review Notes

I could not reproduce the issue as described in the ticket, so I just faked the text in `FingerprintAuthDialogFragment.onFailed`.


## Screenshots or Videos

![photo_2019-03-25_22-19-36](https://user-images.githubusercontent.com/20106814/54954964-4a0d3880-4f4c-11e9-9a22-512e84b4c639.jpg)


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers

- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
