### PR TITLE
383: Change font in spinner item list

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -52,7 +52,7 @@
 
     <style name="TextAppearanceWidgetEventToolbarTitle">
         <item name="android:letterSpacing">0.01</item>
-        <item name="android:fontFamily">sans-serif</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:textSize">20sp</item>
         <item name="android:textColor">@android:color/white</item>
         <item name="android:background">@color/color_primary</item>


### PR DESCRIPTION
Fixes #383 

## Testing and Review Notes

To see the problem, I visually compared the title of the list screen with titles from other screens (account, settings, etc).
It was found that the first title was lighter than the others.

## Screenshots or Videos
**Before**
![Screenshot_20190326-131049](https://user-images.githubusercontent.com/21011641/54998967-9e0d3100-4fcf-11e9-9797-e3c16e1b06b2.jpg)

**After**
![Screenshot_20190326-131012](https://user-images.githubusercontent.com/21011641/54998957-9d749a80-4fcf-11e9-9479-ae0b37a9dd14.jpg)


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
