### PR TITLE
nullsafe operations on FingerprintManager 

### DIFF
--- a/app/src/main/java/mozilla/lockbox/store/FingerprintStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/FingerprintStore.kt
@@ -37,7 +37,7 @@ open class FingerprintStore(
     val dispatcher: Dispatcher = Dispatcher.shared
 ) : ContextStore {
     internal val compositeDisposable = CompositeDisposable()
-    open lateinit var fingerprintManager: FingerprintManager
+    open var fingerprintManager: FingerprintManager? = null
     open lateinit var keyguardManager: KeyguardManager
     private lateinit var authenticationCallback: AuthenticationCallback
 
@@ -75,7 +75,7 @@ open class FingerprintStore(
     }
 
     override fun injectContext(context: Context) {
-        fingerprintManager = context.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager
+        fingerprintManager = context.getSystemService(Context.FINGERPRINT_SERVICE) as? FingerprintManager
         keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
         authenticationCallback = AuthenticationCallback(context)
     }
@@ -84,7 +84,7 @@ open class FingerprintStore(
         get() = isFingerprintAuthAvailable || isKeyguardDeviceSecure
 
     open val isFingerprintAuthAvailable: Boolean
-        get() = fingerprintManager.isHardwareDetected && fingerprintManager.hasEnrolledFingerprints()
+        get() = (fingerprintManager?.isHardwareDetected ?: false) && (fingerprintManager?.hasEnrolledFingerprints() ?: false)
 
     open val isKeyguardDeviceSecure get() = keyguardManager.isDeviceSecure
 
@@ -103,7 +103,7 @@ open class FingerprintStore(
         }
         cancellationSignal = CancellationSignal()
         selfCancelled = false
-        fingerprintManager.authenticate(cryptoObject, cancellationSignal, 0, authenticationCallback, null)
+        fingerprintManager?.authenticate(cryptoObject, cancellationSignal, 0, authenticationCallback, null)
     }
 
     private fun stopListening() {

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -37,8 +37,8 @@ class LockedPresenterTest {
     }
 
     open class FakeFingerprintStore : FingerprintStore() {
-        override var fingerprintManager: FingerprintManager =
-            RuntimeEnvironment.application.getSystemService(Context.FINGERPRINT_SERVICE) as FingerprintManager
+        override var fingerprintManager: FingerprintManager? =
+            RuntimeEnvironment.application.getSystemService(Context.FINGERPRINT_SERVICE) as? FingerprintManager
 
         override var keyguardManager: KeyguardManager =
             spy(RuntimeEnvironment.application.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager)


### PR DESCRIPTION
Fixes #207 

## Testing and Review Notes

Just build it and install on older device, such as Nexus 4 where it won't event start and now it works properly.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] modify unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
