### PR TITLE
541: Fix mismatch in unlock screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         <activity
                 android:name=".view.RootActivity"
                 android:label="@string/app_label"
-                android:windowSoftInputMode="adjustResize"
+                android:windowSoftInputMode="adjustUnspecified"
                 android:configChanges="orientation|keyboardHidden"
                 android:screenOrientation="portrait">
             <intent-filter>

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -253,13 +253,13 @@ class RoutePresenter(
             R.id.fragment_onboarding_confirmation to R.id.fragment_item_list -> R.id.action_to_itemList
             R.id.fragment_onboarding_confirmation to R.id.fragment_webview -> R.id.action_to_webview
 
-            R.id.fragment_locked to R.id.fragment_item_list -> R.id.action_to_itemList
+            R.id.fragment_locked to R.id.fragment_item_list -> R.id.action_locked_to_itemList
             R.id.fragment_locked to R.id.fragment_welcome -> R.id.action_locked_to_welcome
 
             R.id.fragment_item_list to R.id.fragment_item_detail -> R.id.action_itemList_to_itemDetail
             R.id.fragment_item_list to R.id.fragment_setting -> R.id.action_itemList_to_setting
             R.id.fragment_item_list to R.id.fragment_account_setting -> R.id.action_itemList_to_accountSetting
-            R.id.fragment_item_list to R.id.fragment_locked -> R.id.action_to_locked
+            R.id.fragment_item_list to R.id.fragment_locked -> R.id.action_itemList_to_locked
             R.id.fragment_item_list to R.id.fragment_filter -> R.id.action_itemList_to_filter
             R.id.fragment_item_list to R.id.fragment_webview -> R.id.action_to_webview
 


### PR DESCRIPTION
Fixes #541 

## Testing and Review Notes

It happened to me only when I unlock with a numerical combination because the keyboard does not close in time for the button and the image to 'go down' to its original position.
The solution found was to let the system manage whether readjust the screen or focus on the text field to be written, in the RootActivity. Ref: [Input mode](https://developer.android.com/guide/topics/manifest/activity-element.html#wsoft)

On the other hand, remove the log error that will appear as soon as you debug the problem. This error was caused by the lack of action in the navigation in the graph_main.xml

## Screenshots or Videos

**Before**
![Before](https://user-images.githubusercontent.com/21011641/55150792-2f55e200-514d-11e9-9c6c-c65d8078bc7d.gif)

**After**
![After](https://user-images.githubusercontent.com/21011641/55150630-d1c19580-514c-11e9-9da3-531c8b945416.gif)

PS: The part of the screen that is black, is from Huawei's own system to insert the password

## To Do

- [X] double check the original issue to confirm it is fully satisfied
- [X] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [X] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
