### PR TITLE
Treat kotlin warnings as errors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -233,3 +233,7 @@ if (project.hasProperty("coverage")) {
         }
     }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions.allWarningsAsErrors = true
+}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,7 +124,7 @@ dependencies {
     testImplementation "org.powermock:powermock-api-mockito2:2.0.0-beta.5"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"
     androidTestImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"
-    androidTestImplementation "androidx.test:core:$androidxTest_version"
+    testImplementation "androidx.test:core:$androidxTest_version"
     androidTestImplementation "androidx.test.ext:junit:$androidxTest_version"
     androidTestImplementation "androidx.test:runner:$androidxTest_version"
     androidTestImplementation "androidx.test:rules:$androidxTest_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,7 @@ dependencies {
     implementation "android.arch.navigation:navigation-ui-ktx:$navigation_version"
     implementation 'com.adjust.sdk:adjust-android:4.17.0'
     implementation 'com.android.installreferrer:installreferrer:1.0'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.22.0'
     testImplementation 'org.robolectric:robolectric:4.0.2'

--- a/app/src/androidTest/java/mozilla/lockbox/ItemDetailsTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/ItemDetailsTest.kt
@@ -2,6 +2,7 @@ package mozilla.lockbox
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.robots.itemDetail
 import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.view.RootActivity
@@ -9,6 +10,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 open class ItemDetailsTest {
     private val navigator = Navigator()

--- a/app/src/androidTest/java/mozilla/lockbox/ItemListTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/ItemListTest.kt
@@ -2,12 +2,14 @@ package mozilla.lockbox
 
 import androidx.test.rule.ActivityTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.robots.itemList
 import mozilla.lockbox.view.RootActivity
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 open class ItemListTest {
     private val navigator = Navigator()

--- a/app/src/androidTest/java/mozilla/lockbox/OnboardingTest.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/OnboardingTest.kt
@@ -2,6 +2,7 @@ package mozilla.lockbox
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.robots.autofillOnboardingScreen
 import mozilla.lockbox.robots.fingerprintOnboardingScreen
 import mozilla.lockbox.robots.fxaLogin
@@ -13,6 +14,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 open class OnboardingTest {
 

--- a/app/src/androidTest/java/mozilla/lockbox/robots/BaseTestRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/BaseTestRobot.kt
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+@file:Suppress("DEPRECATION")
+
 package mozilla.lockbox.robots
 
 import androidx.test.espresso.Espresso

--- a/app/src/androidTest/java/mozilla/lockbox/robots/ItemDetailRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/ItemDetailRobot.kt
@@ -14,13 +14,12 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.rule.ActivityTestRule
 import br.com.concretesolutions.kappuccino.actions.ClickActions
 import br.com.concretesolutions.kappuccino.assertions.VisibilityAssertions.displayed
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.view.RootActivity
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.not
 
-@ExperimentalCoroutinesApi
+@Suppress("EXPERIMENTAL_API_USAGE", "EXPERIMENTAL_API_USAGE_ERROR", "EXPERIMENTAL_IS_NOT_ENABLED")
 class ItemDetailRobot : BaseTestRobot {
     override fun exists() = displayed {
         id(R.id.inputHostname)
@@ -36,5 +35,4 @@ class ItemDetailRobot : BaseTestRobot {
             .check(matches(isDisplayed()))
 }
 
-@UseExperimental(ExperimentalCoroutinesApi::class)
 fun itemDetail(f: ItemDetailRobot.() -> Unit) = ItemDetailRobot().apply(f)

--- a/app/src/androidTest/java/mozilla/lockbox/robots/ItemDetailRobot.kt
+++ b/app/src/androidTest/java/mozilla/lockbox/robots/ItemDetailRobot.kt
@@ -14,12 +14,13 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.rule.ActivityTestRule
 import br.com.concretesolutions.kappuccino.actions.ClickActions
 import br.com.concretesolutions.kappuccino.assertions.VisibilityAssertions.displayed
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.view.RootActivity
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.not
 
-// ItemDetail
+@ExperimentalCoroutinesApi
 class ItemDetailRobot : BaseTestRobot {
     override fun exists() = displayed {
         id(R.id.inputHostname)
@@ -35,4 +36,5 @@ class ItemDetailRobot : BaseTestRobot {
             .check(matches(isDisplayed()))
 }
 
+@UseExperimental(ExperimentalCoroutinesApi::class)
 fun itemDetail(f: ItemDetailRobot.() -> Unit) = ItemDetailRobot().apply(f)

--- a/app/src/debug/java/mozilla/lockbox/view/UITestActivity.kt
+++ b/app/src/debug/java/mozilla/lockbox/view/UITestActivity.kt
@@ -7,6 +7,7 @@
 package mozilla.lockbox.view
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import mozilla.lockbox.R
 import mozilla.lockbox.log
@@ -17,7 +18,7 @@ class UITestActivity : AppCompatActivity() {
         setContentView(R.layout.activity_test)
     }
 
-    fun launchFingerprint() {
+    fun launchFingerprint(@Suppress("UNUSED_PARAMETER") view: View) {
         val dialogFragment = FingerprintAuthDialogFragment()
         val fragmentManager = this.supportFragmentManager
         try {

--- a/app/src/debug/java/mozilla/lockbox/view/UITestActivity.kt
+++ b/app/src/debug/java/mozilla/lockbox/view/UITestActivity.kt
@@ -6,9 +6,8 @@
 
 package mozilla.lockbox.view
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import mozilla.lockbox.R
 import mozilla.lockbox.log
 
@@ -18,7 +17,7 @@ class UITestActivity : AppCompatActivity() {
         setContentView(R.layout.activity_test)
     }
 
-    fun launchFingerprint(view: View) {
+    fun launchFingerprint() {
         val dialogFragment = FingerprintAuthDialogFragment()
         val fragmentManager = this.supportFragmentManager
         try {

--- a/app/src/main/java/mozilla/lockbox/extensions/ViewNode+.kt
+++ b/app/src/main/java/mozilla/lockbox/extensions/ViewNode+.kt
@@ -12,11 +12,7 @@ fun AssistStructure.ViewNode.dump(): String {
 
 @TargetApi(Build.VERSION_CODES.O)
 private fun AssistStructure.ViewNode.dumpNode(sb: StringBuilder = StringBuilder()): StringBuilder {
-    val name = if (htmlInfo != null) {
-        htmlInfo.tag
-    } else {
-        className.split('.').last()
-    }
+    val name = htmlInfo?.tag ?: className.split('.').last()
 
     var attrs = listOf(
         Pair("idEntry", idEntry ?: ""),

--- a/app/src/main/java/mozilla/lockbox/model/ItemDetailViewModel.kt
+++ b/app/src/main/java/mozilla/lockbox/model/ItemDetailViewModel.kt
@@ -13,6 +13,6 @@ data class ItemDetailViewModel(
     val username: String?,
     val password: String
 ) {
-    var hasUsername: Boolean = false
+    val hasUsername: Boolean
         get() = !username.isNullOrBlank()
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/FxALoginPresenter.kt
@@ -46,7 +46,7 @@ class FxALoginPresenter(
 
     override fun onViewReady() {
         view.webViewRedirect = { url ->
-            val urlStr = url?.toString() ?: null
+            val urlStr = url?.toString()
             val result = isRedirectUri(urlStr)
             if (result) {
                 dispatcher.dispatch(OnboardingStatusAction(true))

--- a/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/ClipboardStore.kt
@@ -20,6 +20,7 @@ open class ClipboardStore(
     val dispatcher: Dispatcher = Dispatcher.shared
 ) : ContextStore {
     internal val compositeDisposable = CompositeDisposable()
+
     companion object {
         val shared = ClipboardStore()
     }
@@ -29,19 +30,19 @@ open class ClipboardStore(
 
     init {
         dispatcher.register
-                .filterByType(ClipboardAction::class.java)
-                .subscribe {
-                    // unpack the action, including adding new Clips to the Clipboard.
-                    when (it) {
-                        is ClipboardAction.CopyUsername -> {
-                            addToClipboard("username", it.username)
-                        }
-                        is ClipboardAction.CopyPassword -> {
-                            addToClipboard("password", it.password)
-                        }
+            .filterByType(ClipboardAction::class.java)
+            .subscribe {
+                // unpack the action, including adding new Clips to the Clipboard.
+                when (it) {
+                    is ClipboardAction.CopyUsername -> {
+                        addToClipboard("username", it.username)
+                    }
+                    is ClipboardAction.CopyPassword -> {
+                        addToClipboard("password", it.password)
                     }
                 }
-                .addTo(compositeDisposable)
+            }
+            .addTo(compositeDisposable)
     }
 
     override fun injectContext(context: Context) {
@@ -61,8 +62,8 @@ open class ClipboardStore(
     }
 
     fun replaceDirty(dirty: String, clean: String = "") {
-        val clipData = clipboardManager.primaryClip.getItemAt(0)
-        if (clipData.text == dirty) {
+        val clipData = clipboardManager.primaryClip?.getItemAt(0)
+        if (clipData?.text == dirty) {
             clipboardManager.primaryClip = ClipData.newPlainText("", clean)
         }
     }

--- a/app/src/main/java/mozilla/lockbox/store/DataStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/DataStore.kt
@@ -202,7 +202,9 @@ open class DataStore(
         this.listSubject.accept(emptyList())
     }
 
+    // Parameter x is needed to ensure that the function is indeed a Consumer so that it can be used in a suscribe-call
     // there's probably a slicker way to do this `Unit` thing...
+    @Suppress("UNUSED_PARAMETER")
     private fun updateList(x: Unit) {
         val backend = this.backend ?: return notReady()
         if (!backend.isLocked()) {

--- a/app/src/main/java/mozilla/lockbox/store/NetworkStore.kt
+++ b/app/src/main/java/mozilla/lockbox/store/NetworkStore.kt
@@ -4,12 +4,12 @@ import android.content.Context
 import android.net.ConnectivityManager
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
+import io.reactivex.subjects.ReplaySubject
 import mozilla.lockbox.action.NetworkAction
 import mozilla.lockbox.extensions.filterByType
 import mozilla.lockbox.flux.Dispatcher
-import io.reactivex.disposables.CompositeDisposable
-import io.reactivex.subjects.ReplaySubject
 
 open class NetworkStore(
     val dispatcher: Dispatcher = Dispatcher.shared
@@ -22,7 +22,7 @@ open class NetworkStore(
     val isConnected: Observable<Boolean>
 
     val isConnectedState: Boolean
-        get() = connectivityManager.activeNetworkInfo?.isConnectedOrConnecting == true
+        get() = connectivityManager.activeNetworkInfo?.isConnected == true
 
     companion object {
         val shared = NetworkStore()

--- a/app/src/main/java/mozilla/lockbox/support/FixedDataStoreSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/FixedDataStoreSupport.kt
@@ -21,7 +21,7 @@ class FixedDataStoreSupport(
 ) : DataStoreSupport {
     var size = getRandomInRange(40, 50)
     private val logins = MemoryLoginsStorage(
-        values ?: List(size) { createDummyItem(it) } + listOf(createDummyIPItem())
+        values ?: List(size) { createDummyItem() } + listOf(createDummyIPItem())
     )
 
     override var encryptionKey: String = "shh-keep-it-secret"
@@ -45,7 +45,7 @@ class FixedDataStoreSupport(
  * Some functionality inspired by FxA 'upload_fake_passwords.py'
  * https://gist.github.com/rfk/916d9ca684f862b1c1030c685a5a4d19
  */
-internal fun createDummyItem(idx: Int): ServerPassword {
+internal fun createDummyItem(): ServerPassword {
     val random = Random()
     val id = UUID.randomUUID().toString()
     val pwd = createRandomPassword()

--- a/app/src/main/java/mozilla/lockbox/support/LockingSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/LockingSupport.kt
@@ -3,10 +3,10 @@ package mozilla.lockbox.support
 import android.os.SystemClock
 
 interface LockingSupport {
-    var systemTimeElapsed: Long
+    val systemTimeElapsed: Long
 }
 
 class SystemLockingSupport : LockingSupport {
-    override var systemTimeElapsed: Long = 0L
+    override val systemTimeElapsed: Long
         get() = SystemClock.elapsedRealtime()
 }

--- a/app/src/main/java/mozilla/lockbox/support/PulicSuffixSupport.kt
+++ b/app/src/main/java/mozilla/lockbox/support/PulicSuffixSupport.kt
@@ -83,6 +83,7 @@ data class PublicSuffix(
         this.topDomain.equals(expected.topDomain, true)
 }
 
+@ExperimentalCoroutinesApi
 private fun asyncDomain(pslSupport: PublicSuffixSupport, webDomain: String?, packageName: String) =
     // resolve the (webDomain || packageName) to a 1+publicsuffix =
     when (webDomain) {
@@ -95,6 +96,7 @@ private data class FillablePassword(
     val entry: ServerPassword
 )
 
+@ExperimentalCoroutinesApi
 fun Observable<List<ServerPassword>>.filter(pslSupport: PublicSuffixSupport, webDomain: String?, packageName: String): Observable<List<ServerPassword>> {
     val passwords = this.switchMap { serverPasswords ->
         val parsedPasswords = serverPasswords

--- a/app/src/main/java/mozilla/lockbox/view/AutofillFilterFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/AutofillFilterFragment.kt
@@ -16,7 +16,6 @@ import android.view.inputmethod.InputMethodManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
-import com.jakewharton.rxbinding2.widget.text
 import com.jakewharton.rxbinding2.widget.textChanges
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
@@ -68,7 +67,7 @@ class AutofillFilterFragment : DialogFragment(), AutofillFilterView {
         get() = view!!.filterField.textChanges()
 
     override val filterText: Consumer<in CharSequence>
-        get() = view!!.filterField.text()
+        get() = Consumer { newText -> view!!.filterField.setText(newText) }
     override val cancelButtonClicks: Observable<Unit>
         get() = view!!.cancelButton.clicks()
     override val cancelButtonVisibility: Consumer<in Boolean>

--- a/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/FilterFragment.kt
@@ -8,15 +8,14 @@ package mozilla.lockbox.view
 
 import android.content.Context
 import android.os.Bundle
-import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.jakewharton.rxbinding2.view.clicks
 import com.jakewharton.rxbinding2.view.visibility
-import com.jakewharton.rxbinding2.widget.text
 import com.jakewharton.rxbinding2.widget.textChanges
 import io.reactivex.Observable
 import io.reactivex.functions.Consumer
@@ -72,7 +71,7 @@ class FilterFragment : BackableFragment(), FilterView {
     override val filterTextEntered: Observable<CharSequence>
         get() = view!!.filterField.textChanges()
     override val filterText: Consumer<in CharSequence>
-        get() = view!!.filterField.text()
+        get() = Consumer { newText -> view!!.filterField.setText(newText) }
     override val cancelButtonClicks: Observable<Unit>
         get() = view!!.cancelButton.clicks()
     override val cancelButtonVisibility: Consumer<in Boolean>

--- a/app/src/test/java/mozilla/lockbox/DispatcherTest.kt
+++ b/app/src/test/java/mozilla/lockbox/DispatcherTest.kt
@@ -6,10 +6,10 @@
 
 package mozilla.lockbox
 
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
-import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.flux.Action
+import mozilla.lockbox.flux.Dispatcher
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -24,7 +24,7 @@ class DispatcherTest {
         val dispatcher = Dispatcher()
         val onNextExecuted = AtomicBoolean(false)
 
-        val subscription = dispatcher.register.subscribe { _ -> onNextExecuted.set(true) }
+        val subscription = dispatcher.register.subscribe { onNextExecuted.set(true) }
         assertFalse(onNextExecuted.get())
         dispatcher.dispatch(TestAction.UNIT)
         assertTrue(onNextExecuted.get())

--- a/app/src/test/java/mozilla/lockbox/StackReplaySubjectTest.kt
+++ b/app/src/test/java/mozilla/lockbox/StackReplaySubjectTest.kt
@@ -7,10 +7,9 @@
 package mozilla.lockbox
 
 import io.reactivex.observers.TestObserver
-import junit.framework.Assert.assertEquals
 import mozilla.lockbox.extensions.assertLastValue
-
 import mozilla.lockbox.flux.StackReplaySubject
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/app/src/test/java/mozilla/lockbox/adapter/ItemListAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/ItemListAdapterTest.kt
@@ -9,6 +9,7 @@ package mozilla.lockbox.adapter
 import android.content.Context
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import io.reactivex.observers.TestObserver
 import kotlinx.android.synthetic.main.list_cell_item.*
 import kotlinx.android.synthetic.main.list_cell_no_entries.view.*
@@ -22,7 +23,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -46,7 +46,7 @@ class ItemListAdapterTest {
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
+        context = ApplicationProvider.getApplicationContext()
         parent = RecyclerView(context)
         parent.layoutManager = LinearLayoutManager(context)
     }

--- a/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/ListAdapterTestHelper.kt
@@ -22,7 +22,7 @@ class ListAdapterTestHelper {
     private val toggleObserverFake = TestObserver<Boolean>()
     private val toggleConsumerFake = TestConsumer(toggleObserverFake) as Consumer<Boolean>
     private val textClicksObserverFake = TestObserver<Unit>()
-    private val textClicksConsumerFake = TestConsumer(toggleObserverFake) as Consumer<Unit>
+    private val textClicksConsumerFake = TestConsumer(textClicksObserverFake)
     private val expectedVersionNumber = BuildConfig.VERSION_NAME
 
     fun createListOfSettings(): List<SettingCellConfiguration> {
@@ -56,7 +56,10 @@ class ListAdapterTestHelper {
         )
     }
 
-    fun createAccurateListOfSettings(isFingerprintAvailable: Boolean, isAutofillAvailable: Boolean): List<SettingCellConfiguration> {
+    fun createAccurateListOfSettings(
+        isFingerprintAvailable: Boolean,
+        isAutofillAvailable: Boolean
+    ): List<SettingCellConfiguration> {
         var settings: List<SettingCellConfiguration> = listOf(
             TextSettingConfiguration(
                 title = R.string.auto_lock,
@@ -76,7 +79,8 @@ class ListAdapterTestHelper {
             )
         }
 
-        settings += listOf(ToggleSettingConfiguration(
+        settings += listOf(
+            ToggleSettingConfiguration(
                 title = R.string.send_usage_data,
                 subtitle = R.string.send_usage_data_summary,
                 contentDescription = R.string.empty_string,

--- a/app/src/test/java/mozilla/lockbox/adapter/SectionedAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/SectionedAdapterTest.kt
@@ -7,9 +7,10 @@
 package mozilla.lockbox.adapter
 
 import android.content.Context
+import android.widget.LinearLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
 import mozilla.lockbox.R
 import mozilla.lockbox.adapter.SectionedAdapter.Section
 import mozilla.lockbox.view.ToggleSettingViewHolder
@@ -20,7 +21,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -34,7 +34,8 @@ class SectionedAdapterTest {
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
+
+        context = ApplicationProvider.getApplicationContext()
         parent = RecyclerView(context)
         parent.layoutManager = LinearLayoutManager(context)
         testHelper = ListAdapterTestHelper()

--- a/app/src/test/java/mozilla/lockbox/adapter/SettingListAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/SettingListAdapterTest.kt
@@ -9,12 +9,13 @@ package mozilla.lockbox.adapter
 import android.content.Context
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ApplicationProvider
 import mozilla.lockbox.BuildConfig
 import mozilla.lockbox.R
 import mozilla.lockbox.adapter.SettingListAdapter.Companion.SETTING_TEXT_TYPE
 import mozilla.lockbox.adapter.SettingListAdapter.Companion.SETTING_TOGGLE_TYPE
-import mozilla.lockbox.view.TextSettingViewHolder
 import mozilla.lockbox.view.AppVersionSettingViewHolder
+import mozilla.lockbox.view.TextSettingViewHolder
 import mozilla.lockbox.view.ToggleSettingViewHolder
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Assert
@@ -24,7 +25,6 @@ import org.junit.Test
 import org.junit.jupiter.api.Assertions
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -45,7 +45,7 @@ class SettingListAdapterTest {
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application
+        context = ApplicationProvider.getApplicationContext()
         parent = RecyclerView(context)
         parent.layoutManager = LinearLayoutManager(context)
         testHelper = ListAdapterTestHelper()

--- a/app/src/test/java/mozilla/lockbox/adapter/SortItemAdapterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/adapter/SortItemAdapterTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Color
 import android.widget.ListView
 import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
 import mozilla.lockbox.R
 import mozilla.lockbox.action.Setting
 import org.hamcrest.Matchers.instanceOf
@@ -15,7 +16,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -31,7 +31,7 @@ class SortItemAdapterTest {
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         subject = SortItemAdapter(context, android.R.layout.simple_spinner_item, ArrayList(list))
     }
 

--- a/app/src/test/java/mozilla/lockbox/autofill/FillResponseBuilderTest.kt
+++ b/app/src/test/java/mozilla/lockbox/autofill/FillResponseBuilderTest.kt
@@ -6,14 +6,15 @@
 
 package mozilla.lockbox.autofill
 
+import android.content.Context
 import android.view.autofill.AutofillId
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -25,7 +26,7 @@ class FillResponseBuilderTest {
     @Mock
     val passwordId = mock(AutofillId::class.java)
 
-    val context = RuntimeEnvironment.application.applicationContext
+    val context: Context = ApplicationProvider.getApplicationContext()
     val parsedStructure = ParsedStructure(usernameId = usernameId, passwordId = passwordId, packageName = "mozilla.lockbox")
     val subject = FillResponseBuilder(parsedStructure)
 

--- a/app/src/test/java/mozilla/lockbox/autofill/IntentBuilderTest.kt
+++ b/app/src/test/java/mozilla/lockbox/autofill/IntentBuilderTest.kt
@@ -6,8 +6,10 @@
 
 package mozilla.lockbox.autofill
 
+import android.content.Context
 import android.content.Intent
 import android.view.autofill.AutofillId
+import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -16,7 +18,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -25,7 +26,7 @@ class IntentBuilderTest {
     val passwordId = mock(AutofillId::class.java)
     val parsedStructure = ParsedStructure(usernameId, passwordId, "webDomain", "packageName")
     val fillResponseBuilder = FillResponseBuilder(parsedStructure)
-    val context = RuntimeEnvironment.systemContext
+    val context: Context = ApplicationProvider.getApplicationContext()
 
     @Test
     fun `auth intent sender`() {

--- a/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
+++ b/app/src/test/java/mozilla/lockbox/mocks/MockLoginsStorage.kt
@@ -16,7 +16,7 @@ import mozilla.lockbox.support.createDummyItem
 import org.mockito.Mockito
 
 open class MockLoginsStorage : LoginsStorage {
-    private val all = MutableList(10) { createDummyItem(it) }
+    private val all = MutableList(10) { createDummyItem() }
 
     private var _locked = true
 

--- a/app/src/test/java/mozilla/lockbox/presenter/AppWebPageActionPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AppWebPageActionPresenterTest.kt
@@ -5,6 +5,7 @@ import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.NetworkStore
@@ -19,6 +20,7 @@ import org.powermock.api.mockito.PowerMockito
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class AppWebPageActionPresenterTest {
@@ -34,7 +36,7 @@ class AppWebPageActionPresenterTest {
             networkAvailable.onNext(networkErrorVisibility)
         }
 
-        open var loadedUrl: String? = null
+        var loadedUrl: String? = null
         override var webViewObserver: Consumer<String>? = null
         override fun loadURL(url: String) {
             loadedUrl = url

--- a/app/src/test/java/mozilla/lockbox/presenter/AppWebPageActionPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AppWebPageActionPresenterTest.kt
@@ -5,11 +5,11 @@ import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
-import junit.framework.Assert.assertEquals
 import mozilla.lockbox.flux.Action
 import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.NetworkStore
 import mozilla.lockbox.support.Constant
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/mozilla/lockbox/presenter/AutofillFilterPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AutofillFilterPresenterTest.kt
@@ -10,9 +10,6 @@ import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.appservices.logins.ServerPassword
 import mozilla.lockbox.TestConsumer
@@ -24,6 +21,9 @@ import mozilla.lockbox.model.ItemViewModel
 import mozilla.lockbox.store.DataStore
 import mozilla.lockbox.support.Optional
 import mozilla.lockbox.support.asOptional
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/mozilla/lockbox/presenter/AutofillLockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AutofillLockedPresenterTest.kt
@@ -9,8 +9,6 @@ package mozilla.lockbox.presenter
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertTrue
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.R
 import mozilla.lockbox.action.AutofillAction
@@ -23,6 +21,8 @@ import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.FingerprintStore
 import mozilla.lockbox.store.LockedStore
 import mozilla.lockbox.store.SettingStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/mozilla/lockbox/presenter/AutofillOnboardingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AutofillOnboardingPresenterTest.kt
@@ -2,6 +2,7 @@ package mozilla.lockbox.presenter
 
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.RouteAction
 import mozilla.lockbox.action.SettingIntent
 import mozilla.lockbox.flux.Action
@@ -13,6 +14,7 @@ import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class AutofillOnboardingPresenterTest {

--- a/app/src/test/java/mozilla/lockbox/presenter/AutofillRoutePresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/AutofillRoutePresenterTest.kt
@@ -23,7 +23,6 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.internal.schedulers.ExecutorScheduler
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
-import junit.framework.Assert.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.appservices.logins.ServerPassword
 import mozilla.lockbox.R
@@ -42,6 +41,7 @@ import mozilla.lockbox.support.PublicSuffixSupport
 import mozilla.lockbox.view.AutofillFilterFragment
 import mozilla.lockbox.view.FingerprintAuthDialogFragment
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/mozilla/lockbox/presenter/FilterPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FilterPresenterTest.kt
@@ -10,6 +10,7 @@ import io.reactivex.Observable
 import io.reactivex.functions.Consumer
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.appservices.logins.ServerPassword
 import mozilla.lockbox.TestConsumer
 import mozilla.lockbox.action.AppWebPageAction
@@ -25,6 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class FilterPresenterTest {
     class FakeView : FilterView {

--- a/app/src/test/java/mozilla/lockbox/presenter/FingerprintDialogPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FingerprintDialogPresenterTest.kt
@@ -3,6 +3,7 @@ package mozilla.lockbox.presenter
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.FingerprintAuthAction
 import mozilla.lockbox.action.FingerprintSensorAction
 import mozilla.lockbox.extensions.assertLastValue
@@ -18,6 +19,7 @@ import org.mockito.Mockito.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class FingerprintDialogPresenterTest {

--- a/app/src/test/java/mozilla/lockbox/presenter/FingerprintOnboardingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FingerprintOnboardingPresenterTest.kt
@@ -5,6 +5,7 @@ import android.view.autofill.AutofillManager
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.subjects.PublishSubject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.action.FingerprintAuthAction
 import mozilla.lockbox.action.FingerprintSensorAction
 import mozilla.lockbox.action.SettingAction
@@ -23,6 +24,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.mockito.Mockito.`when` as whenCalled
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class FingerprintOnboardingPresenterTest {

--- a/app/src/test/java/mozilla/lockbox/presenter/FingerprintOnboardingPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/FingerprintOnboardingPresenterTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package mozilla.lockbox.presenter
 
 import android.hardware.fingerprint.FingerprintManager

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -37,11 +37,13 @@ class LockedPresenterTest {
     }
 
     open class FakeFingerprintStore : FingerprintStore() {
+        private val context: Context = ApplicationProvider.getApplicationContext()
+
         override var fingerprintManager: FingerprintManager? =
-            ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.FINGERPRINT_SERVICE) as? FingerprintManager
+            context.getSystemService(Context.FINGERPRINT_SERVICE) as? FingerprintManager
 
         override var keyguardManager: KeyguardManager =
-            spy(ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager)
+            spy(context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager)
     }
 
     class FakeLockedStore : LockedStore() {

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -3,6 +3,7 @@ package mozilla.lockbox.presenter
 import android.app.KeyguardManager
 import android.content.Context
 import android.hardware.fingerprint.FingerprintManager
+import androidx.test.core.app.ApplicationProvider
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
@@ -23,7 +24,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.spy
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -38,10 +38,10 @@ class LockedPresenterTest {
 
     open class FakeFingerprintStore : FingerprintStore() {
         override var fingerprintManager: FingerprintManager? =
-            RuntimeEnvironment.application.getSystemService(Context.FINGERPRINT_SERVICE) as? FingerprintManager
+            ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.FINGERPRINT_SERVICE) as? FingerprintManager
 
         override var keyguardManager: KeyguardManager =
-            spy(RuntimeEnvironment.application.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager)
+            spy(ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager)
     }
 
     class FakeLockedStore : LockedStore() {
@@ -73,7 +73,7 @@ class LockedPresenterTest {
 
     @Before
     fun setUp() {
-        context = RuntimeEnvironment.application.applicationContext
+        context = ApplicationProvider.getApplicationContext()
         subject.onViewReady()
     }
 

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package mozilla.lockbox.presenter
 
 import android.app.KeyguardManager

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -6,9 +6,6 @@ import android.hardware.fingerprint.FingerprintManager
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertFalse
-import junit.framework.Assert.assertTrue
 import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.FingerprintAuthAction
 import mozilla.lockbox.action.RouteAction
@@ -17,6 +14,9 @@ import mozilla.lockbox.flux.Dispatcher
 import mozilla.lockbox.store.FingerprintStore
 import mozilla.lockbox.store.LockedStore
 import mozilla.lockbox.store.SettingStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/ClipboardStoreTest.kt
@@ -9,6 +9,7 @@ package mozilla.lockbox.store
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.ClipboardAction
 import mozilla.lockbox.flux.Dispatcher
@@ -19,7 +20,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.mockito.Mockito.`when` as whenCalled
 
@@ -34,7 +34,7 @@ class ClipboardStoreTest : DisposingTest() {
     val context: Context = Mockito.mock(Context::class.java)
 
     private val clipboardManager =
-        RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
     @Before
     fun setUp() {
@@ -48,7 +48,7 @@ class ClipboardStoreTest : DisposingTest() {
     fun testCopyUsername() {
         val testString = "my_test_string"
         dispatcher.dispatch(ClipboardAction.CopyUsername(testString))
-        val clip = clipboardManager.primaryClip.getItemAt(0)
+        val clip = clipboardManager.primaryClip?.getItemAt(0) ?: throw AssertionError("PrimaryClip must not be null")
         Assert.assertEquals(testString, clip.text)
     }
 
@@ -56,7 +56,7 @@ class ClipboardStoreTest : DisposingTest() {
     fun testCopyPassword() {
         val testString = "my_test_password"
         dispatcher.dispatch(ClipboardAction.CopyPassword(testString))
-        val clip = clipboardManager.primaryClip.getItemAt(0)
+        val clip = clipboardManager.primaryClip?.getItemAt(0) ?: throw AssertionError("PrimaryClip must not be null")
         Assert.assertEquals(testString, clip.text)
     }
 
@@ -66,11 +66,11 @@ class ClipboardStoreTest : DisposingTest() {
 
         dispatcher.dispatch(ClipboardAction.CopyPassword(testString))
 
-        val dirty = clipboardManager.primaryClip.getItemAt(0)
+        val dirty = clipboardManager.primaryClip?.getItemAt(0) ?: throw AssertionError("PrimaryClip must not be null")
         Assert.assertEquals(testString, dirty.text)
 
         subject.replaceDirty(testString)
-        val clean = clipboardManager.primaryClip.getItemAt(0)
+        val clean = clipboardManager.primaryClip?.getItemAt(0) ?: throw AssertionError("PrimaryClip must not be null")
         Assert.assertEquals("", clean.text)
     }
 
@@ -80,14 +80,14 @@ class ClipboardStoreTest : DisposingTest() {
 
         dispatcher.dispatch(ClipboardAction.CopyPassword(testString))
 
-        val dirty = clipboardManager.primaryClip.getItemAt(0)
+        val dirty = clipboardManager.primaryClip?.getItemAt(0) ?: throw AssertionError("PrimaryClip must not be null")
         Assert.assertEquals(testString, dirty.text)
 
         val url = "https://www.mozilla.org"
         clipboardManager.primaryClip = ClipData.newPlainText("url", url)
 
         subject.replaceDirty(testString)
-        val clean = clipboardManager.primaryClip.getItemAt(0)
+        val clean = clipboardManager.primaryClip?.getItemAt(0) ?: throw AssertionError("PrimaryClip must not be null")
         Assert.assertEquals(url, clean.text)
     }
 }

--- a/app/src/test/java/mozilla/lockbox/store/FingerprintStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/FingerprintStoreTest.kt
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+@file:Suppress("DEPRECATION")
+
 package mozilla.lockbox.store
 
 import android.app.KeyguardManager

--- a/app/src/test/java/mozilla/lockbox/store/NetworkStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/NetworkStoreTest.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
 import android.preference.PreferenceManager
-import junit.framework.Assert.assertEquals
 import mozilla.lockbox.DisposingTest
 import mozilla.lockbox.action.NetworkAction
 import mozilla.lockbox.flux.Dispatcher
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -7,27 +7,27 @@
 package mozilla.lockbox.store
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import io.reactivex.Observable
 import io.reactivex.subjects.BehaviorSubject
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.ReplaySubject
 import mozilla.lockbox.DisposingTest
+import mozilla.lockbox.action.ClipboardAction
+import mozilla.lockbox.action.DataStoreAction
 import mozilla.lockbox.action.LifecycleAction
 import mozilla.lockbox.action.RouteAction
-import mozilla.lockbox.action.DataStoreAction
-import mozilla.lockbox.action.ClipboardAction
-import mozilla.lockbox.action.TelemetryAction
-import mozilla.lockbox.action.SettingAction
 import mozilla.lockbox.action.Setting
+import mozilla.lockbox.action.SettingAction
+import mozilla.lockbox.action.TelemetryAction
 import mozilla.lockbox.extensions.assertLastValue
 import mozilla.lockbox.extensions.assertLastValueMatches
 import mozilla.lockbox.flux.Dispatcher
-import org.junit.Test
 import org.junit.Assert
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.telemetry.event.TelemetryEvent
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
@@ -42,6 +42,7 @@ class TelemetryStoreTest : DisposingTest() {
         override fun lateinitContext(ctx: Context) {
             applySubject.onNext(ctx)
         }
+
         override fun recordEvent(event: TelemetryEvent) {
             eventsSubject.onNext(event)
         }
@@ -64,8 +65,8 @@ class TelemetryStoreTest : DisposingTest() {
     fun testApplyConfig() {
         val applyObserver = createTestObserver<Context>()
         wrapper.applySubject.subscribe(applyObserver)
-        subject.injectContext(RuntimeEnvironment.application)
-        applyObserver.assertValue(RuntimeEnvironment.application)
+        subject.injectContext(ApplicationProvider.getApplicationContext())
+        applyObserver.assertValue(ApplicationProvider.getApplicationContext<Context>())
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
+++ b/app/src/test/java/mozilla/lockbox/store/TelemetryStoreTest.kt
@@ -64,9 +64,10 @@ class TelemetryStoreTest : DisposingTest() {
     @Test
     fun testApplyConfig() {
         val applyObserver = createTestObserver<Context>()
+        val context: Context = ApplicationProvider.getApplicationContext()
         wrapper.applySubject.subscribe(applyObserver)
-        subject.injectContext(ApplicationProvider.getApplicationContext())
-        applyObserver.assertValue(ApplicationProvider.getApplicationContext<Context>())
+        subject.injectContext(context)
+        applyObserver.assertValue(context)
     }
 
     @Test

--- a/app/src/test/java/mozilla/lockbox/support/PublicSuffixSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/PublicSuffixSupportTest.kt
@@ -320,7 +320,7 @@ class PublicSuffixSupportTest : DisposingTest() {
         val domains = listOf("example.com", "firefox.com", "accounts.firefox.com", "mozilla.org")
         val passwords = domains.map { ServerPassword(id = it, hostname = "https://$it", username = it, password = it) }
 
-        val (example, firefox1, firefox2, mozilla) = passwords
+        val (example, firefox1, firefox2) = passwords
 
         fun testFiltering(
             webDomain: String?,

--- a/app/src/test/java/mozilla/lockbox/support/PublicSuffixSupportTest.kt
+++ b/app/src/test/java/mozilla/lockbox/support/PublicSuffixSupportTest.kt
@@ -9,6 +9,7 @@
 package mozilla.lockbox.support
 
 import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import io.reactivex.Observable
 import io.reactivex.observers.TestObserver
 import io.reactivex.rxkotlin.Observables
@@ -22,7 +23,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 typealias PublicSuffixPair = Pair<PublicSuffix, PublicSuffix>
@@ -31,7 +31,7 @@ typealias PublicSuffixPair = Pair<PublicSuffix, PublicSuffix>
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class PublicSuffixSupportTest : DisposingTest() {
-    private val appContext: Context = RuntimeEnvironment.application
+    private val appContext: Context = ApplicationProvider.getApplicationContext()
     private val support = PublicSuffixSupport()
 
     @Before
@@ -322,7 +322,11 @@ class PublicSuffixSupportTest : DisposingTest() {
 
         val (example, firefox1, firefox2, mozilla) = passwords
 
-        fun testFiltering(webDomain: String?, packageName: String = "com.android.chrome", vararg expected: ServerPassword) {
+        fun testFiltering(
+            webDomain: String?,
+            packageName: String = "com.android.chrome",
+            vararg expected: ServerPassword
+        ) {
             val matchObserver = createTestObserver<List<ServerPassword>>()
             Observable.just(passwords)
                 .filter(support, webDomain, packageName)

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.sentry:sentry-android-gradle-plugin:1.7.10'


### PR DESCRIPTION
Fixes #482 

## Testing and Review Notes

In an effort to treat warnings as errors in kotlin, this PR aims to remove many/all warnings currently found in the code.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
