### PR TITLE
WIP — Merge route presenters. DO NOT MERGE

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/AbstractRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AbstractRoutePresenter.kt
@@ -154,7 +154,7 @@ abstract class AbstractRoutePresenter(
         }
     }
 
-    protected abstract fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int?
+    protected abstract fun findTransitionId(@IdRes src: Int, @IdRes dest: Int): Int?
 
     protected fun openWebsite(url: String) {
         val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))

--- a/app/src/main/java/mozilla/lockbox/presenter/AbstractRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AbstractRoutePresenter.kt
@@ -1,0 +1,169 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox.presenter
+
+import android.app.KeyguardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
+import androidx.annotation.IdRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.navigation.NavController
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxkotlin.addTo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.lockbox.R
+import mozilla.lockbox.action.DialogAction
+import mozilla.lockbox.action.RouteAction
+import mozilla.lockbox.extensions.view.AlertDialogHelper
+import mozilla.lockbox.extensions.view.AlertState
+import mozilla.lockbox.flux.Dispatcher
+import mozilla.lockbox.flux.Presenter
+import mozilla.lockbox.log
+import mozilla.lockbox.store.RouteStore
+import mozilla.lockbox.view.DialogFragment
+
+@ExperimentalCoroutinesApi
+abstract class AbstractRoutePresenter(
+    internal val activity: AppCompatActivity,
+    internal val dispatcher: Dispatcher = Dispatcher.shared,
+    internal val routeStore: RouteStore = RouteStore.shared
+) : Presenter() {
+
+    protected lateinit var navController: NavController
+
+    private val backListener = OnBackPressedCallback {
+        dispatcher.dispatch(RouteAction.InternalBack)
+        false
+    }
+
+    private val navHostFragmentManager: FragmentManager
+        get() {
+            val fragmentManager = activity.supportFragmentManager
+            val navHost = fragmentManager.fragments.last()
+            return navHost.childFragmentManager
+        }
+
+    private val currentFragment: Fragment
+        get() {
+            return navHostFragmentManager.fragments.last()
+        }
+
+    override fun onPause() {
+        super.onPause()
+        activity.removeOnBackPressedCallback(backListener)
+        compositeDisposable.clear()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        activity.addOnBackPressedCallback(backListener)
+        routeStore.routes
+            .distinctUntilChanged()
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe(this::route)
+            .addTo(compositeDisposable)
+    }
+
+    protected abstract fun route(action: RouteAction)
+
+    protected fun showDialog(destination: DialogAction) {
+        AlertDialogHelper.showAlertDialog(activity, destination.viewModel)
+            .map { alertState ->
+                when (alertState) {
+                    AlertState.BUTTON_POSITIVE -> {
+                        destination.positiveButtonActionList
+                    }
+                    AlertState.BUTTON_NEGATIVE -> {
+                        destination.negativeButtonActionList
+                    }
+                }
+            }
+            .flatMapIterable { listOf(RouteAction.InternalBack) + it }
+            .subscribe(dispatcher::dispatch)
+            .addTo(compositeDisposable)
+    }
+
+    protected fun showDialogFragment(dialogFragment: DialogFragment, destination: RouteAction.DialogFragment) {
+        try {
+            dialogFragment.setTargetFragment(currentFragment, 0)
+            dialogFragment.show(navHostFragmentManager, dialogFragment.javaClass.name)
+            dialogFragment.setupDialog(destination.dialogTitle, destination.dialogSubtitle)
+        } catch (e: IllegalStateException) {
+            log.error("Could not show dialog", e)
+        }
+    }
+
+    protected fun showUnlockFallback(action: RouteAction.UnlockFallbackDialog) {
+        val manager = activity.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        val intent = manager.createConfirmDeviceCredentialIntent(
+            activity.getString(R.string.unlock_fallback_title),
+            activity.getString(R.string.confirm_pattern)
+        )
+        currentFragment.startActivityForResult(intent, action.requestCode)
+    }
+
+    protected fun navigateToFragment(@IdRes destinationId: Int, args: Bundle? = null) {
+        val src = navController.currentDestination ?: return
+        val srcId = src.id
+        if (srcId == destinationId && args == null) {
+            // No point in navigating if nothing has changed.
+            return
+        }
+
+        val transition = findTransitionId(srcId, destinationId) ?: destinationId
+
+        val navOptions = if (transition == destinationId) {
+            // Without being able to detect if we're in developer mode,
+            // it is too dangerous to RuntimeException.
+            val from = activity.resources.getResourceName(srcId)
+            val to = activity.resources.getResourceName(destinationId)
+            val graphName = activity.resources.getResourceName(navController.graph.id)
+            log.error(
+                "Cannot route from $from to $to. " +
+                    "This is a developer bug, fixable by adding an action to $graphName.xml and/or ${javaClass.simpleName}"
+            )
+            null
+        } else {
+            // Get the transition action out of the graph, before we manually clear the back
+            // stack, because it causes IllegalArgumentExceptions.
+            src.getAction(transition)?.navOptions?.let { navOptions ->
+                if (navOptions.shouldLaunchSingleTop()) {
+                    while (navController.popBackStack()) {
+                        // NOP
+                    }
+                    routeStore.clearBackStack()
+                }
+                navOptions
+            }
+        }
+
+        try {
+            navController.navigate(destinationId, args, navOptions)
+        } catch (e: Throwable) {
+            log.error("This appears to be a bug in navController", e)
+            navController.navigate(destinationId, args)
+        }
+    }
+
+    protected abstract fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int?
+
+    protected fun openWebsite(url: String) {
+        val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        activity.startActivity(browserIntent, null)
+    }
+
+    protected fun openSetting(settingAction: RouteAction.SystemSetting) {
+        val settingIntent = Intent(settingAction.setting.intentAction)
+        settingIntent.data = settingAction.setting.data
+        activity.startActivity(settingIntent, null)
+    }
+}

--- a/app/src/main/java/mozilla/lockbox/presenter/AutofillLockedPresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AutofillLockedPresenter.kt
@@ -22,7 +22,6 @@ import mozilla.lockbox.store.SettingStore
 import java.util.concurrent.TimeUnit
 
 interface AutofillLockedView {
-    fun unlockFallback()
     val unlockConfirmed: Observable<Boolean>
 }
 
@@ -78,7 +77,7 @@ class AutofillLockedPresenter(
 
     private fun unlockFallback() {
         if (fingerprintStore.isKeyguardDeviceSecure) {
-            lockedView.unlockFallback()
+            dispatcher.dispatch(RouteAction.UnlockFallbackDialog)
         } else {
             unlock()
         }

--- a/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
@@ -76,13 +76,13 @@ class AutofillRoutePresenter(
     override fun route(action: RouteAction) {
         when (action) {
             is RouteAction.LockScreen -> navigateToFragment(R.id.fragment_locked)
-            is RouteAction.ItemList -> showDialogFragment(AutofillFilterFragment(),
+            is RouteAction.ItemList -> showDialogFragment(
+                AutofillFilterFragment(),
                 RouteAction.DialogFragment.AutofillSearchDialog
             )
-            is RouteAction.DialogFragment.FingerprintDialog ->
-                showDialogFragment(FingerprintAuthDialogFragment(), action)
-        }
-    }
+            is RouteAction.DialogFragment.FingerprintDialog -> showDialogFragment(
+                FingerprintAuthDialogFragment(),
+                action
             )
         }
     }
@@ -98,7 +98,7 @@ class AutofillRoutePresenter(
 
     private fun finishAutofill(action: AutofillAction) {
         when (action) {
-            is AutofillAction.Cancel -> setFillResponseAndFinish()
+            is AutofillAction.Cancel -> cancelAndFinish()
             is AutofillAction.Complete -> finishResponse(listOf(action.login))
             is AutofillAction.CompleteMultiple -> finishResponse(action.logins)
         }
@@ -106,15 +106,17 @@ class AutofillRoutePresenter(
 
     private fun finishResponse(passwords: List<ServerPassword>) {
         val response = responseBuilder.buildFilteredFillResponse(activity, passwords)
-        setFillResponseAndFinish(response)
+        response?.let { setFillResponseAndFinish(it) } ?: cancelAndFinish()
     }
 
-    private fun setFillResponseAndFinish(fillResponse: FillResponse? = null) {
-        if (fillResponse == null) {
-            activity.setResult(Activity.RESULT_CANCELED)
-        } else {
-            activity.setResult(Activity.RESULT_OK, Intent().putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, fillResponse))
-        }
+    private fun cancelAndFinish() {
+        activity.setResult(Activity.RESULT_CANCELED)
+        activity.finish()
+    }
+
+    private fun setFillResponseAndFinish(fillResponse: FillResponse) {
+        val results = Intent().putExtra(AutofillManager.EXTRA_AUTHENTICATION_RESULT, fillResponse)
+        activity.setResult(Activity.RESULT_OK, results)
         activity.finish()
     }
 }

--- a/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AutofillRoutePresenter.kt
@@ -84,11 +84,12 @@ class AutofillRoutePresenter(
                 FingerprintAuthDialogFragment(),
                 action
             )
+            is RouteAction.UnlockFallbackDialog -> showUnlockFallback(action)
         }
     }
 
-    override fun findTransitionId(@IdRes from: Int, @IdRes to: Int): Int? {
-        return when (Pair(from, to)) {
+    override fun findTransitionId(@IdRes src: Int, @IdRes dest: Int): Int? {
+        return when (Pair(src, dest)) {
             Pair(R.id.fragment_locked, R.id.fragment_filter) -> R.id.action_locked_to_filter
             Pair(R.id.fragment_null, R.id.fragment_filter) -> R.id.action_to_filter
             Pair(R.id.fragment_null, R.id.fragment_locked) -> R.id.action_to_locked

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -43,8 +43,7 @@ class RoutePresenter(
         when (action) {
             is RouteAction.Welcome -> navigateToFragment(R.id.fragment_welcome)
             is RouteAction.Login -> navigateToFragment(R.id.fragment_fxa_login)
-            is RouteAction.Onboarding.FingerprintAuth ->
-                navigateToFragment(R.id.fragment_fingerprint_onboarding)
+            is RouteAction.Onboarding.FingerprintAuth -> navigateToFragment(R.id.fragment_fingerprint_onboarding)
             is RouteAction.Onboarding.Autofill -> navigateToFragment(R.id.fragment_autofill_onboarding)
             is RouteAction.Onboarding.Confirmation -> navigateToFragment(R.id.fragment_onboarding_confirmation)
             is RouteAction.ItemList -> navigateToFragment(R.id.fragment_item_list)
@@ -57,8 +56,10 @@ class RoutePresenter(
             is RouteAction.SystemSetting -> openSetting(action)
             is RouteAction.UnlockFallbackDialog -> showUnlockFallback(action)
             is RouteAction.AutoLockSetting -> showAutoLockSelections()
-            is RouteAction.DialogFragment.FingerprintDialog ->
-                showDialogFragment(FingerprintAuthDialogFragment(), action)
+            is RouteAction.DialogFragment.FingerprintDialog -> showDialogFragment(
+                FingerprintAuthDialogFragment(),
+                action
+            )
             is DialogAction -> showDialog(action)
             is AppWebPageAction -> navigateToFragment(R.id.fragment_webview, bundle(action))
         }
@@ -83,7 +84,7 @@ class RoutePresenter(
         // This maps two nodes in the graph_main.xml to the edge between them.
         // If a RouteAction is called from a place the graph doesn't know about then
         // the app will log.error.
-        return when (from to to) {
+        return when (src to dest) {
             R.id.fragment_null to R.id.fragment_item_list -> R.id.action_init_to_unlocked
             R.id.fragment_null to R.id.fragment_locked -> R.id.action_init_to_locked
             R.id.fragment_null to R.id.fragment_welcome -> R.id.action_init_to_unprepared

--- a/app/src/main/java/mozilla/lockbox/view/AutofillLockedFragment.kt
+++ b/app/src/main/java/mozilla/lockbox/view/AutofillLockedFragment.kt
@@ -7,17 +7,13 @@
 package mozilla.lockbox.view
 
 import android.app.Activity
-import android.app.KeyguardManager
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import io.reactivex.Observable
 import io.reactivex.subjects.PublishSubject
-import mozilla.lockbox.R
 import mozilla.lockbox.presenter.AutofillLockedPresenter
 import mozilla.lockbox.presenter.AutofillLockedView
-
-private const val LOCK_REQUEST_CODE = 112
+import mozilla.lockbox.support.Constant
 
 class AutofillLockedFragment : Fragment(), AutofillLockedView {
     private val _unlockConfirmed = PublishSubject.create<Boolean>()
@@ -34,24 +30,11 @@ class AutofillLockedFragment : Fragment(), AutofillLockedView {
         presenter.onDestroy()
     }
 
-    override fun unlockFallback() {
-        val manager = context?.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-        val intent = manager.createConfirmDeviceCredentialIntent(
-            getString(R.string.unlock_fallback_title),
-            getString(R.string.confirm_pattern)
-        )
-        try {
-            startActivityForResult(intent, LOCK_REQUEST_CODE)
-        } catch (exception: Exception) {
-            _unlockConfirmed.onNext(false)
-        }
-    }
-
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == Activity.RESULT_OK) {
             when (requestCode) {
-                LOCK_REQUEST_CODE -> _unlockConfirmed.onNext(true)
+                Constant.RequestCode.unlock -> _unlockConfirmed.onNext(true)
             }
         } else {
             _unlockConfirmed.onNext(false)


### PR DESCRIPTION
This is a work in progress, with no more work on it. 

TODO:

 - [ ] — move registering of subscribers and calls to clear the composite disposable to their own methods (and call them from the relevant lifecycle methods)
 - [ ] — consider putting the back listener into the super class.
 - [ ] — check that autofill still works as expected. 
 - [ ] — check that autofill doesn't interfere with the app (e.g. switch between the app on `ItemDetail`, or `Setting` and the search screen on Autofill).
 - [ ] — consider an `AutofillRouteStore`.

This PR is not ready to merge, but may be useful for anyone else trying to fix #508.