### PR TITLE
autolock on device restart

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
                 <action android:name="com.android.vending.INSTALL_REFERRER" />
             </intent-filter>
         </receiver>
-        
+
         <receiver android:name=".BootReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
             xmlns:tools="http://schemas.android.com/tools"
@@ -56,6 +57,12 @@
                 android:exported="true" >
             <intent-filter>
                 <action android:name="com.android.vending.INSTALL_REFERRER" />
+            </intent-filter>
+        </receiver>
+        
+        <receiver android:name=".BootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/java/mozilla/lockbox/BootReceiver.kt
+++ b/app/src/main/java/mozilla/lockbox/BootReceiver.kt
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.preference.PreferenceManager
+import mozilla.lockbox.support.Constant
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (!intent?.action.equals("android.intent.action.BOOT_COMPLETED")) {
+            return
+        }
+
+        context?.let {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(it)
+
+            prefs
+                .edit()
+                .putLong(Constant.Key.autoLockTimerDate, 0)
+                .apply()
+        }
+    }
+}

--- a/app/src/test/java/mozilla/lockbox/BootReceiverTest.kt
+++ b/app/src/test/java/mozilla/lockbox/BootReceiverTest.kt
@@ -1,0 +1,75 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package mozilla.lockbox
+
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+import mozilla.lockbox.support.Constant
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyZeroInteractions
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
+import org.mockito.Mockito.`when` as whenCalled
+
+@RunWith(PowerMockRunner::class)
+@PrepareForTest(PreferenceManager::class)
+class BootReceiverTest {
+    @Mock
+    val editor: SharedPreferences.Editor = Mockito.mock(SharedPreferences.Editor::class.java)
+
+    @Mock
+    val preferences: SharedPreferences = Mockito.mock(SharedPreferences::class.java)
+
+    @Mock
+    val context = Mockito.mock(Context::class.java)
+
+    @Mock
+    val intent = Mockito.mock(Intent::class.java)
+
+    val subject = BootReceiver()
+
+    @Test
+    fun `receiving unexpected intents`() {
+        subject.onReceive(context, intent)
+
+        verifyZeroInteractions(context)
+        verifyZeroInteractions(preferences)
+    }
+
+    @Test
+    fun `receiving expected intents with a null context`() {
+        whenCalled(intent.action).thenReturn("android.intent.action.BOOT_COMPLETED")
+        subject.onReceive(null, intent)
+
+        verifyZeroInteractions(context)
+        verifyZeroInteractions(preferences)
+    }
+
+    @Test
+    fun `receiving expected intents with a context object`() {
+        whenCalled(intent.action).thenReturn("android.intent.action.BOOT_COMPLETED")
+        Mockito.`when`(editor.putLong(anyString(), anyLong())).thenReturn(editor)
+        Mockito.`when`(preferences.edit()).thenReturn(editor)
+        PowerMockito.mockStatic(PreferenceManager::class.java)
+        Mockito.`when`(PreferenceManager.getDefaultSharedPreferences(context)).thenReturn(preferences)
+
+        subject.onReceive(context, intent)
+
+        verify(preferences).edit()
+        verify(editor).putLong(Constant.Key.autoLockTimerDate, 0)
+        verify(editor).apply()
+    }
+}


### PR DESCRIPTION
Fixes #510

## Testing and Review Notes

bug description is sufficient to describe the problem; the expected behavior is that the app will _always_ be locked after restarting the device (unless the Autolock time is `Never`)

the boot notification gets sent ~1 minute after the device is started up, so there is a brief window in which the lock screen can still be bypassed. however, the notification is always sent after the user has authenticated at a device level (PIN only) for the first time after a restart, so it's unlikely that Lockbox security would prevent accessing passwords in this case anyway.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
