### PR TITLE
Configure Android App Bundle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,13 @@ android {
 
         buildConfigField "int", "BITRISE_BUILD_NUMBER", System.getenv("BITRISE_BUILD_NUMBER") ?: "0"
     }
+
+    bundle {
+        language {
+            enableSplit = true
+        }
+    }
+
     buildTypes {
         debug {
             debuggable true


### PR DESCRIPTION
Fixes #544 

## Testing and Review Notes

I tried to evaluate the benefits of Android App Bundles in this specific usecase. I tested it with an AVD running as a Pixel 2 XL in english language (x86) and my OnePlus One in german language (arm)

|Variant|File Size | Expected Download Size*|
|---|---|---|
|Debug APK|49.1MB|?|
|Debug Bundle (OnePlus One)|47.2MB|18.5MB|
|Debug Bundle (Emulator) | 47.5MB|18.6MB|
|Release APK|41.5MB|?|
|Release Bundle (OnePlus One)|45.9 MB| 17.2MB|
|Release Bundle (Emulator) | 46.2MB | 17.3MB|

*The expected download size was optained by running [bundletool](ff) with the options `get-size total`. The numbers that were returend did not have a unit. But my best guess is, that the unit was bytes. For better readability, I converted them to Megabytes.

The bigger task would be to change how the app is published to Google Play. But I guess this has to be done by someone from the Mozilla Team :)

## To Do

- [ ] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
