### PR TITLE
Fix race condition in LocketPresenterTest and make it non-flaky

### DIFF
--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -83,8 +83,8 @@ class LockedPresenterTest {
 
     @Test
     fun `unlock button tap shows fingerprint dialog`() {
-        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
+        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         view.unlockButtonTaps.onNext(Unit)
         val unlockingAction = dispatchIterator.next() as UnlockingAction
         assertTrue(unlockingAction.currently)
@@ -95,9 +95,9 @@ class LockedPresenterTest {
 
     @Test
     fun `unlock button tap fallback if no fingerprint`() {
-        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
+        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         view.unlockButtonTaps.onNext(Unit)
         settingStore.unlock.onNext(false)
         assertTrue(dispatchIterator.next() is UnlockingAction)
@@ -106,18 +106,18 @@ class LockedPresenterTest {
 
     @Test
     fun `unlock button tap fallback on fingerprint error`() {
-        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
+        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         lockedStore.onAuth.onNext(FingerprintAuthAction.OnError)
         assertEquals(RouteAction.UnlockFallbackDialog, dispatchIterator.next())
     }
 
     @Test
     fun `onviewready when can launch authentication shows fingerprint dialog`() {
+        `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         (lockedStore.canLaunchAuthenticationOnForeground as Subject).onNext(true)
-        `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
         settingStore.unlock.onNext(true)
         val unlockingAction = dispatchIterator.next() as UnlockingAction
         assertTrue(unlockingAction.currently)
@@ -127,11 +127,11 @@ class LockedPresenterTest {
 
     @Test
     fun `onviewready when can launch authentication if no fingerprint`() {
+        `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
+        `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         (lockedStore.canLaunchAuthenticationOnForeground as Subject).onNext(true)
 
-        `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
-        `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
         settingStore.unlock.onNext(false)
         val unlockingAction = dispatchIterator.next() as UnlockingAction
         assertTrue(unlockingAction.currently)
@@ -140,9 +140,9 @@ class LockedPresenterTest {
 
     @Test
     fun `foreground action fallback on fingerprint error`() {
-        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
+        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         lockedStore.onAuth.onNext(FingerprintAuthAction.OnError)
         assertEquals(RouteAction.UnlockFallbackDialog, dispatchIterator.next())
     }
@@ -159,8 +159,8 @@ class LockedPresenterTest {
 
     @Test
     fun `handle error authentication callback when the device has no other security`() {
-        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(false)
+        val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         lockedStore.onAuth.onNext(FingerprintAuthAction.OnError)
 
         assertEquals(DataStoreAction.Unlock, dispatchIterator.next())

--- a/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
+++ b/app/src/test/java/mozilla/lockbox/presenter/LockedPresenterTest.kt
@@ -84,6 +84,7 @@ class LockedPresenterTest {
     @Test
     fun `unlock button tap shows fingerprint dialog`() {
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
+
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         view.unlockButtonTaps.onNext(Unit)
         val unlockingAction = dispatchIterator.next() as UnlockingAction
@@ -97,6 +98,7 @@ class LockedPresenterTest {
     fun `unlock button tap fallback if no fingerprint`() {
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
+
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         view.unlockButtonTaps.onNext(Unit)
         settingStore.unlock.onNext(false)
@@ -108,6 +110,7 @@ class LockedPresenterTest {
     fun `unlock button tap fallback on fingerprint error`() {
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
+
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         lockedStore.onAuth.onNext(FingerprintAuthAction.OnError)
         assertEquals(RouteAction.UnlockFallbackDialog, dispatchIterator.next())
@@ -116,6 +119,7 @@ class LockedPresenterTest {
     @Test
     fun `onviewready when can launch authentication shows fingerprint dialog`() {
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
+
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         (lockedStore.canLaunchAuthenticationOnForeground as Subject).onNext(true)
         settingStore.unlock.onNext(true)
@@ -129,6 +133,7 @@ class LockedPresenterTest {
     fun `onviewready when can launch authentication if no fingerprint`() {
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(false)
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
+
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         (lockedStore.canLaunchAuthenticationOnForeground as Subject).onNext(true)
 
@@ -142,6 +147,7 @@ class LockedPresenterTest {
     fun `foreground action fallback on fingerprint error`() {
         `when`(fingerprintStore.isFingerprintAuthAvailable).thenReturn(true)
         `when`(fingerprintStore.isKeyguardDeviceSecure).thenReturn(true)
+
         val dispatchIterator = dispatcher.register.blockingIterable().iterator()
         lockedStore.onAuth.onNext(FingerprintAuthAction.OnError)
         assertEquals(RouteAction.UnlockFallbackDialog, dispatchIterator.next())


### PR DESCRIPTION
Fixes #539
Fixes #572 

## Testing and Review Notes

By moving the mocks up, the race condition can be resolved. Otherwise it would be possible, that the mocking would not be completed when the events are emitted.

## Personal note

Wow...Fixing this was quite a bit of work, but I finally got it! Also I learned quite a bit of RxJava on the way so I guess it was worth it. I hope you are happy with the patch!

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
