### PR TITLE
Add French, German, Spanish, Italian to l10n.toml, fixes #519

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -1,7 +1,9 @@
-
 basepath = "."
 
 locales = [
+  "de",
+  "es",
+  "fr",
 ]
 [env]
 

--- a/l10n.toml
+++ b/l10n.toml
@@ -4,6 +4,7 @@ locales = [
   "de",
   "es",
   "fr",
+  "it"
 ]
 [env]
 


### PR DESCRIPTION
Fixes #519

## Testing and Review Notes

This adds the locales mentioned in https://github.com/mozilla-l10n/android-l10n/issues/14 to the l10n config.

CC @Delphine 