### PR TITLE
document autofill metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -168,13 +168,13 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 	* `category`: action
 	* `method`:
 		* autofill_error (there was an error when attempting to fill a form),
-		* autofill_single (the autofill API returned one credential that fit a form),
-		* autofill_multiple (the autofill API returned multiple possible matches to a form),
+		* autofill_multiple (the autofill API returned a list possible credentials to fill a form),
+		* autofill_single (a credential was selected from the list of possible credentials to fill a form),
 		* autofill_filter (the user filtered a returned list of autofill credentials),
 		* autofill_locked (the datastore was locked when a form triggered the autofill API),
 		* autofill_cancel (the user cancelled form autofill),
-		* background (always when the app is backgrounded?),
-		* foreground (always when the app is foregrounded?)
+		* background (when the autofill service is backgrounded, doesn't necessarily involve user-facing UX),
+		* foreground (always when the autofill service is foregrounded, doesn't necessarily involve user-facing UX)
 	* `object`: autofill
 	* `value`: null
 	* `extras`: null

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -164,6 +164,21 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 	* `value`: null
 	* `extras`: null
 
+13. When a user interacts with the autofill functionality
+	* `category`: action
+	* `method`:
+		* autofill_error (there was an error when attempting to fill a form),
+		* autofill_single (the autofill API returned one credential that fit a form),
+		* autofill_multiple (the autofill API returned multiple possible matches to a form),
+		* autofill_filter (the user filtered a returned list of autofill credentials),
+		* autofill_locked (the datastore was locked when a form triggered the autofill API),
+		* autofill_cancel (the user cancelled form autofill),
+		* background (always when the app is backgrounded?),
+		* foreground (always when the app is foregrounded?)
+	* `object`: autofill
+	* `value`: null
+	* `extras`: null
+
 
 ## Adjust SDK
 


### PR DESCRIPTION
Hi Sasha, can you clarify any of my misconceptions about what the autofill events measure, or if there was a better way to describe them? I'm pretty sketchy on their meaning and it will help me narrow down my queries to only count those events that are involved with the user actually trying to use autofill. 

(anyone else can jump in here as well, but I think it was sasha who implemented the events)