### PR TITLE
561: Sentry not logging errors or crashes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation "org.mozilla.components:lib-dataprotect:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-publicsuffixlist:${rootProject.ext.android_components_version}"
-    implementation 'io.sentry:sentry-android:1.7.14'
+    implementation 'io.sentry:sentry-android:1.7.16'
     implementation "com.squareup.picasso:picasso:$picasso_version"
     implementation project(":thirdparty")
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation "org.mozilla.components:lib-dataprotect:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-fetch-httpurlconnection:${rootProject.ext.android_components_version}"
     implementation "org.mozilla.components:lib-publicsuffixlist:${rootProject.ext.android_components_version}"
-    implementation 'io.sentry:sentry-android:1.7.16'
+    implementation "io.sentry:sentry-android:$sentry_version"
     implementation "com.squareup.picasso:picasso:$picasso_version"
     implementation project(":thirdparty")
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"
@@ -152,6 +152,18 @@ appservices {
         megazord = 'lockbox'
         unitTestingEnabled = false
     }
+}
+
+sentry {
+    // Disables or enables the automatic configuration of proguard
+    // for Sentry.  This injects a default config for proguard so
+    // you don't need to do it manually.
+    autoProguardConfig false
+
+    // Enables or disables the automatic upload of mapping files
+    // during a build.  If you disable this you'll need to manually
+    // upload the mapping files with sentry-cli when you do a release.
+    autoUpload true
 }
 
 def outputDir = "${project.buildDir}/reports/ktlint/"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         package="mozilla.lockbox">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <!--USE_FINGERPRINT is deprecated in API 28+. Use android.permission.USE_BIOMETRIC instead. -->
     <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 

--- a/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxApplication.kt
@@ -110,10 +110,9 @@ open class LockboxApplication : Application() {
     }
 
     private fun setupSentry() {
-        // Set up Sentry using DSN (client key) from the Project Settings page on Sentry
+        // Set up Sentry using DSN (client key)
         val ctx = this.applicationContext
-        // Retrieved from environment's local (or bitrise's "Secrets") environment variable
-        val sentryDsn: String? = System.getenv("SENTRY_DSN")
+        val sentryDsn = Constant.Sentry.dsn
         Sentry.init(sentryDsn, AndroidSentryClientFactory(ctx))
     }
 

--- a/app/src/main/java/mozilla/lockbox/support/Constant.kt
+++ b/app/src/main/java/mozilla/lockbox/support/Constant.kt
@@ -57,7 +57,6 @@ object Constant {
         const val firefoxAccount = "firefox-account"
         const val encryptionKey = "database-encryption-key"
         const val autoLockTimerDate = "auto-lock-timer-date"
-        const val bootID = "boot-id"
     }
 
     object FingerprintTimeout {
@@ -67,7 +66,10 @@ object Constant {
 
     object RequestCode {
         const val noResult = 0
-
         const val unlock = 221
+    }
+
+    object Sentry {
+        const val dsn = "https://19558af5301f43e1a95ab4b8ceae663b@sentry.prod.mozaws.net/401"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
     ext.androidxTest_version = '1.1.0'
     ext.picasso_version = '2.71828'
     ext.recyclerview_version = '1.1.0-alpha04'
+    ext.sentry_version = '1.7.16'
 
     repositories {
         google()
@@ -29,7 +30,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.3.2'
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.10'
+        classpath "io.sentry:sentry-android-gradle-plugin:$sentry_version"
         classpath "android.arch.navigation:navigation-safe-args-gradle-plugin:$navigation_version"
         classpath 'org.mozilla.appservices:gradle-plugin:0.3.1'
         // NOTE: Do not place your application dependencies here; they belong
@@ -50,3 +51,4 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+


### PR DESCRIPTION
Fixes #561

## Testing and Review Notes
https://docs.sentry.io/clients/java/modules/android/
https://docs.sentry.io/cli/configuration/#configuration-values
Client key: https://sentry.prod.mozaws.net/settings/operations/lockbox-android/keys/

Successful query: https://sentry.prod.mozaws.net/operations/lockbox-android/issues/5518824/?query=is:unresolved


The issue seemed to be that the dsn wasn't being retrieved (locally for debug builds, and from the bitrise public vars in debug/release builds)
```
E/Lockbox: Sentry DSN: null
D/io.sentry.android.AndroidSentryClientFactory: Construction of Android Sentry.
D/io.sentry.android.AndroidSentryClientFactory: Sentry init with ctx='mozilla.lockbox.LockboxApplication@82084c0' and dsn='Dsn{uri=noop://localhost}'
W/io.sentry.android.AndroidSentryClientFactory: *** Couldn't find a suitable DSN, Sentry operations will do nothing! See documentation: https://docs.sentry.io/clients/java/modules/android/ ***
D/io.sentry.android.AndroidSentryClientFactory: Using buffer dir: /data/user/0/mozilla.lockbox/cache/sentry-buffered-events
D/io.sentry.android.event.helper.AndroidEventBuilderHelper: Proguard UUIDs file not found.
```

## Screenshots or Videos

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
