### PR TITLE
Remove deprecated calls of Activity#addOnBackPressedListener

### DIFF
--- a/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/AppRoutePresenter.kt
@@ -4,8 +4,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-@file:Suppress("DEPRECATION")
-
 package mozilla.lockbox.presenter
 
 import android.os.Bundle
@@ -43,13 +41,11 @@ class AppRoutePresenter(
 
     override fun onPause() {
         super.onPause()
-        activity.removeOnBackPressedCallback(backListener)
         compositeDisposable.clear()
     }
 
     override fun onResume() {
         super.onResume()
-        activity.addOnBackPressedCallback(backListener)
         routeStore.routes
             .observeOn(mainThread())
             .subscribe(this::route)

--- a/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
+++ b/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt
@@ -51,7 +51,7 @@ abstract class RoutePresenter(
             return navHostFragmentManager.fragments.last()
         }
 
-    val backListener = OnBackPressedCallback {
+    private val backListener = OnBackPressedCallback {
         dispatcher.dispatch(RouteAction.InternalBack)
         false
     }


### PR DESCRIPTION
Fixes no specific issue

## Testing and Review Notes

We should consider making [backListener in RoutePresenter](https://github.com/beatbrot/lockbox-android/blob/551a8130fb99b22798b1c8fa42b3c2861b9498fb/app/src/main/java/mozilla/lockbox/presenter/RoutePresenter.kt#L54) private since it is not accessed anymore. 

## To Do

- [ ] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding instrumentation (integration/UI) tests
- consider running this branch in a debug simulator and check for memory leak notifications or any warnings
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-android/accessibility/) of any added UI
