### PR TITLE
548: IllegalStateException crash in autofill onFillRequest$5.accept

### DIFF
--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -102,6 +102,7 @@ class LockboxAutofillService(
             .addTo(compositeDisposable)
 
         autofillStore.autofillActions
+            .take(1)
             .map {
                 when (it) {
                     is AutofillAction.Complete -> builder.buildFilteredFillResponse(this, listOf(it.login)).asOptional()
@@ -117,9 +118,11 @@ class LockboxAutofillService(
                 }.asOptional()
             }
             .filterNotNull()
-            .subscribe {
+            .subscribe( {
                 callback.onSuccess(it.value)
-            }
+            }, {
+                log.error(throwable = it)
+            })
             .addTo(compositeDisposable)
     }
 

--- a/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
+++ b/app/src/main/java/mozilla/lockbox/LockboxAutofillService.kt
@@ -118,7 +118,7 @@ class LockboxAutofillService(
                 }.asOptional()
             }
             .filterNotNull()
-            .subscribe( {
+            .subscribe({
                 callback.onSuccess(it.value)
             }, {
                 log.error(throwable = it)


### PR DESCRIPTION
Fixes #548

## Testing and Review Notes


## Screenshots or Videos


## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
