### PR TITLE
Bump to version 1.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,8 +22,8 @@ android {
         minSdkVersion 24
         //noinspection OldTargetApi
         targetSdkVersion 26
-        versionCode 3255
-        versionName "1.0.1"
+        versionCode 3425
+        versionName "1.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/app/src/main/res/layout/list_cell_setting_appversion.xml
+++ b/app/src/main/res/layout/list_cell_setting_appversion.xml
@@ -22,6 +22,6 @@
         android:textAlignment="center"
         android:lineSpacingExtra="6sp"
         android:layout_marginTop="16dp"
-        tools:text="App Version: 1.0.1"/>
+        tools:text="App Version: 1.0.2"/>
     <!-- Set the tools:text value to match versionName from build.gradle -->
 </LinearLayout>


### PR DESCRIPTION
Will wait to confirm the bitrise build number is set and appears as expected (it's "0", also as expected, when testing locally).


<img width="232" alt="image" src="https://user-images.githubusercontent.com/49511/56432295-10e59100-628a-11e9-8ee2-460ba0ac6c7a.png">
