### PR TITLE
set flag_secure for release builds in autofill

### DIFF
--- a/app/src/main/java/mozilla/lockbox/view/AutofillRootActivity.kt
+++ b/app/src/main/java/mozilla/lockbox/view/AutofillRootActivity.kt
@@ -3,11 +3,13 @@ package mozilla.lockbox.view
 import android.annotation.TargetApi
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.lockbox.R
 import mozilla.lockbox.autofill.IntentBuilder
 import mozilla.lockbox.presenter.AutofillRoutePresenter
+import mozilla.lockbox.support.isDebug
 
 @TargetApi(Build.VERSION_CODES.O)
 @ExperimentalCoroutinesApi
@@ -17,6 +19,7 @@ class AutofillRootActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_autofill)
+        if (!isDebug()) window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
 
         // pull responsebuilder & search status out of intent at a later iteration of this
         val responseBuilder = IntentBuilder.getResponseBuilder(intent)


### PR DESCRIPTION
Fixes #634 

## Testing and Review Notes

To test this, pull up some entries in the Autofill Search interface and use the system button to navigate to the app switcher. 

## To Do

- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
